### PR TITLE
Fix auth with Identity v3

### DIFF
--- a/src/Common/Service/Builder.php
+++ b/src/Common/Service/Builder.php
@@ -112,7 +112,10 @@ class Builder
     {
         $identity = isset($options['identityService'])
             ? $options['identityService']
-            : $this->createService('Identity', 3, $options);
+            : $this->createService('Identity', 3, array_merge($options, [
+                'catalogName' => false,
+                'catalogType' => false,
+            ]));
 
         list ($token, $baseUrl) = $identity->authenticate($options);
 

--- a/src/Identity/v3/Models/Service.php
+++ b/src/Identity/v3/Models/Service.php
@@ -83,7 +83,7 @@ class Service extends AbstractResource implements Creatable, Listable, Retrievab
      */
     public function getUrl($name, $type, $region, $urlType)
     {
-        if ($this->name !== $name || $this->type !== $type) {
+        if (($this->name !== $name && !empty($this->name)) || $this->type !== $type) {
             return false;
         }
 
@@ -95,4 +95,4 @@ class Service extends AbstractResource implements Creatable, Listable, Retrievab
 
         return false;
     }
-} 
+}


### PR DESCRIPTION
If Identity service is created in setupHttpClient of the builder, set catalogName and catalogType to false as is done in [OpenStack](https://github.com/php-opencloud/openstack/blob/master/src/OpenStack.php#L72).

The method getUrl of Service, check name only is name is set in the Service. In the OpenStack doc, **name** is marked as optional.

