### PR TITLE
Endpoint of Service with empty region

### DIFF
--- a/src/Identity/v3/Models/Service.php
+++ b/src/Identity/v3/Models/Service.php
@@ -89,7 +89,7 @@ class Service extends AbstractResource implements Creatable, Listable, Retrievab
         }
 
         foreach ($this->endpoints as $endpoint) {
-            if ($endpoint->region == $region && $endpoint->interface == $urlType) {
+            if (($endpoint->region == $region || empty($endpoint->region)) && $endpoint->interface == $urlType) {
                 return $endpoint->url;
             }
         }


### PR DESCRIPTION
I'm execute integration tests against Runabove and in some cases the region of endpoints is empty.

In the OpenStack documentation, region is marked as Optional.