### PR TITLE
Fix class name of specific integration tests

### DIFF
--- a/tests/integration/Runner.php
+++ b/tests/integration/Runner.php
@@ -81,8 +81,9 @@ class Runner
         return $services;
     }
 
-    private function toCamelCase($word, $separator = '_') {
-      return str_replace($separator, '', ucwords($word, $separator));
+    private function toCamelCase($word, $separator = '_')
+    {
+        return str_replace($separator, '', ucwords($word, $separator));
     }
 
     public function runServices()

--- a/tests/integration/Runner.php
+++ b/tests/integration/Runner.php
@@ -81,13 +81,8 @@ class Runner
         return $services;
     }
 
-    private function getCamelCaseStr($className) {
-      $elements = explode('_', $className);
-      $output = '';
-      foreach ($elements as $element) {
-        $output .= ucfirst(trim($element));
-      }
-      return $output;
+    private function toCamelCase($word, $separator = '_') {
+      return str_replace($separator, '', ucwords($word, $separator));
     }
 
     public function runServices()
@@ -99,7 +94,7 @@ class Runner
         foreach ($services as $serviceName => $versions) {
             foreach ($versions as $version) {
 
-                $class = sprintf("%s\\%s\\%sTest", __NAMESPACE__, $this->getCamelCaseStr($serviceName), ucfirst($version));
+                $class = sprintf("%s\\%s\\%sTest", __NAMESPACE__, $this->toCamelCase($serviceName), ucfirst($version));
                 $testRunner = new $class($this->logger, $debugOpt);
 
                 if ($testMethodOpt && method_exists($testRunner, $testMethodOpt)) {

--- a/tests/integration/Runner.php
+++ b/tests/integration/Runner.php
@@ -81,6 +81,15 @@ class Runner
         return $services;
     }
 
+    private function getCamelCaseStr($className) {
+      $elements = explode('_', $className);
+      $output = '';
+      foreach ($elements as $element) {
+        $output .= ucfirst(trim($element));
+      }
+      return $output;
+    }
+
     public function runServices()
     {
         list ($serviceOpt, $versionOpt, $testMethodOpt, $debugOpt) = $this->getOpts();
@@ -90,7 +99,7 @@ class Runner
         foreach ($services as $serviceName => $versions) {
             foreach ($versions as $version) {
 
-                $class = sprintf("%s\\%s\\%sTest", __NAMESPACE__, ucfirst($serviceName), ucfirst($version));
+                $class = sprintf("%s\\%s\\%sTest", __NAMESPACE__, $this->getCamelCaseStr($serviceName), ucfirst($version));
                 $testRunner = new $class($this->logger, $debugOpt);
 
                 if ($testMethodOpt && method_exists($testRunner, $testMethodOpt)) {


### PR DESCRIPTION
The class name of integration test was not properly converted in case
of object store. The service names were collected from samples directory
where object store was represented as "object_store" meanwhile the
integration test name is called "ObjectStore" in camel-case format.

This fix adds a new camel case formatter that properly converts the
object_store to ObjectStore.