### PR TITLE
Refactor normalizeUrl

### DIFF
--- a/src/Common/Service/Builder.php
+++ b/src/Common/Service/Builder.php
@@ -10,6 +10,7 @@ use OpenStack\Common\Auth\ServiceUrlResolver;
 use OpenStack\Common\Auth\Token;
 use OpenStack\Common\Transport\HandlerStack;
 use OpenStack\Common\Transport\Middleware;
+use OpenStack\Common\Transport\Utils;
 use OpenStack\Identity\v3\Service;
 
 /**
@@ -118,19 +119,10 @@ class Builder
         return $stack;
     }
 
-    private function normalizeUrl($url)
-    {
-        if (strpos($url, 'http') === false) {
-            $url = 'http://' . $url;
-        }
-
-        return rtrim($url, '/') . '/';
-    }
-
     private function httpClient($baseUrl, HandlerStack $stack)
     {
         return new Client([
-            'base_uri' => $this->normalizeUrl($baseUrl),
+            'base_uri' => Utils::normalizeUrl($baseUrl),
             'handler'  => $stack,
         ]);
     }

--- a/src/Common/Transport/Utils.php
+++ b/src/Common/Transport/Utils.php
@@ -40,4 +40,23 @@ class Utils
     {
         return (!empty($data) && $key && isset($data[$key])) ? $data[$key] : $data;
     }
+
+    /**
+     * Method for normalize an URL string.
+     *
+     * Append the http:// prefix if not present, and add a
+     * closing url separator when missing.
+     *
+     * @param string $url The url representation.
+     *
+     * @return string
+     */
+    public static function normalizeUrl($url)
+    {
+        if (strpos($url, 'http') === false) {
+            $url = 'http://' . $url;
+        }
+
+        return rtrim($url, '/') . '/';
+    }
 }


### PR DESCRIPTION
Refactor private method Builder.normalizeUrl into OpenStack\Common\Transport\Utils as a public static function. This change makes the normalizeUrl callable from external methdos too.