### PR TITLE
Refactor integration test auth to support v2 identity

### DIFF
--- a/tests/integration/Compute/v2Test.php
+++ b/tests/integration/Compute/v2Test.php
@@ -6,6 +6,7 @@ use OpenStack\Compute\v2\Models\Flavor;
 use OpenStack\Compute\v2\Models\Image;
 use OpenStack\Compute\v2\Models\Server;
 use OpenStack\Integration\TestCase;
+use OpenStack\Integration\Utils;
 use OpenStack\OpenStack;
 
 class V2Test extends TestCase
@@ -18,7 +19,7 @@ class V2Test extends TestCase
     private function getService()
     {
         if (null === $this->service) {
-            $this->service = (new OpenStack())->computeV2($this->getAuthOpts());
+            $this->service = (new OpenStack())->computeV2(Utils::getAuthOpts());
         }
 
         return $this->service;

--- a/tests/integration/Identity/V3Test.php
+++ b/tests/integration/Identity/V3Test.php
@@ -4,28 +4,12 @@ namespace OpenStack\Integration\Identity;
 
 use OpenStack\Identity\v3\Models;
 use OpenStack\Integration\TestCase;
+use OpenStack\Integration\Utils;
 use OpenStack\OpenStack;
 
 class V3Test extends TestCase
 {
     private $service;
-
-    protected function getAuthOpts()
-    {
-        return [
-            'authUrl' => getenv('OS_AUTH_URL'),
-            'region'  => getenv('OS_REGION'),
-            'user'    => [
-                'id'       => getenv('OS_USER_ID'),
-                'password' => getenv('OS_PASSWORD'),
-            ],
-            'scope' => [
-                'project' => [
-                    'id' => getenv('OS_PROJECT_ID'),
-                ]
-            ]
-        ];
-    }
 
     /**
      * @return \OpenStack\Identity\v3\Service
@@ -33,7 +17,7 @@ class V3Test extends TestCase
     private function getService()
     {
         if (null === $this->service) {
-            $this->service = (new OpenStack())->identityV3($this->getAuthOpts());
+            $this->service = (new OpenStack())->identityV3(Utils::getAuthOpts());
         }
 
         return $this->service;

--- a/tests/integration/ObjectStore/V1Test.php
+++ b/tests/integration/ObjectStore/V1Test.php
@@ -4,6 +4,7 @@ namespace OpenStack\Integration\ObjectStore;
 
 use GuzzleHttp\Stream\StreamInterface;
 use OpenStack\Integration\TestCase;
+use OpenStack\Integration\Utils;
 use OpenStack\OpenStack;
 
 class V1Test extends TestCase
@@ -16,7 +17,7 @@ class V1Test extends TestCase
     private function getService()
     {
         if (null === $this->service) {
-            $this->service = (new OpenStack())->objectStoreV1($this->getAuthOpts());
+            $this->service = (new OpenStack())->objectStoreV1(Utils::getAuthOpts());
         }
 
         return $this->service;

--- a/tests/integration/Utils.php
+++ b/tests/integration/Utils.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace OpenStack\Integration;
+
+use GuzzleHttp\Client;
+use OpenStack\Identity\v2\Api;
+use OpenStack\Identity\v2\Service;
+use OpenStack\Common\Transport\HandlerStack;
+
+class Utils
+{
+    public static function getAuthOptsV3()
+    {
+        return [
+            'authUrl' => getenv('OS_AUTH_URL'),
+            'region'  => getenv('OS_REGION_NAME'),
+            'user'    => [
+                'id'       => getenv('OS_USER_ID'),
+                'password' => getenv('OS_PASSWORD'),
+            ],
+            'scope'   => [
+                'project' => [
+                    'id' => getenv('OS_PROJECT_ID'),
+                ]
+            ]
+        ];
+    }
+
+    public static function getAuthOptsV2()
+    {
+        $authUrl = \OpenStack\Common\Transport\Utils::normalizeUrl(getenv('OS_AUTH_URL'));
+        $httpClient = new Client([
+            'base_uri' => $authUrl,
+            'handler'  => HandlerStack::create(),
+        ]);
+        $identityService = new Service($httpClient, new Api);
+        return [
+            'authUrl'         => $authUrl,
+            'region'          => getenv('OS_REGION_NAME'),
+            'username'        => getenv('OS_USERNAME'),
+            'password'        => getenv('OS_PASSWORD'),
+            'tenantName'      => getenv('OS_TENANT_NAME'),
+            'identityService' => $identityService,
+        ];
+    }
+
+    public static function getAuthOpts($options = array())
+    {
+        $auth_options = getenv('OS_IDENTITY_API_VERSION') == '2.0' ?
+            self::getAuthOptsV2() : self::getAuthOptsV3();
+        return array_merge($auth_options, $options);
+    }
+}

--- a/tests/integration/Utils.php
+++ b/tests/integration/Utils.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use OpenStack\Identity\v2\Api;
 use OpenStack\Identity\v2\Service;
 use OpenStack\Common\Transport\HandlerStack;
+use OpenStack\Common\Transport\Utils as CommonUtils;
 
 class Utils
 {
@@ -28,14 +29,13 @@ class Utils
 
     public static function getAuthOptsV2()
     {
-        $authUrl = \OpenStack\Common\Transport\Utils::normalizeUrl(getenv('OS_AUTH_URL'));
         $httpClient = new Client([
-            'base_uri' => $authUrl,
+            'base_uri' => CommonUtils::normalizeUrl(getenv('OS_AUTH_URL')),
             'handler'  => HandlerStack::create(),
         ]);
         $identityService = new Service($httpClient, new Api);
         return [
-            'authUrl'         => $authUrl,
+            'authUrl'         => getenv('OS_AUTH_URL'),
             'region'          => getenv('OS_REGION_NAME'),
             'username'        => getenv('OS_USERNAME'),
             'password'        => getenv('OS_PASSWORD'),
@@ -44,10 +44,10 @@ class Utils
         ];
     }
 
-    public static function getAuthOpts($options = array())
+    public static function getAuthOpts($options = [])
     {
-        $auth_options = getenv('OS_IDENTITY_API_VERSION') == '2.0' ?
+        $authOptions = getenv('OS_IDENTITY_API_VERSION') == '2.0' ?
             self::getAuthOptsV2() : self::getAuthOptsV3();
-        return array_merge($auth_options, $options);
+        return array_merge($authOptions, $options);
     }
 }

--- a/tests/integration/Utils.php
+++ b/tests/integration/Utils.php
@@ -33,21 +33,21 @@ class Utils
             'base_uri' => CommonUtils::normalizeUrl(getenv('OS_AUTH_URL')),
             'handler'  => HandlerStack::create(),
         ]);
-        $identityService = new Service($httpClient, new Api);
         return [
             'authUrl'         => getenv('OS_AUTH_URL'),
             'region'          => getenv('OS_REGION_NAME'),
             'username'        => getenv('OS_USERNAME'),
             'password'        => getenv('OS_PASSWORD'),
             'tenantName'      => getenv('OS_TENANT_NAME'),
-            'identityService' => $identityService,
+            'identityService' => new Service($httpClient, new Api),
         ];
     }
 
-    public static function getAuthOpts($options = [])
+    public static function getAuthOpts(array $options = [])
     {
-        $authOptions = getenv('OS_IDENTITY_API_VERSION') == '2.0' ?
-            self::getAuthOptsV2() : self::getAuthOptsV3();
+        $authOptions = getenv('OS_IDENTITY_API_VERSION') == '2.0'
+            ? self::getAuthOptsV2()
+            : self::getAuthOptsV3();
         return array_merge($authOptions, $options);
     }
 }


### PR DESCRIPTION
Move the integration TestCase auth classes into OpenStack\Integration\Utils. Rewrite the connection substitution code of TestCase.sampleFile to provide v2 auth compatibility for sample classes. Also fix the affected integration tests using the getAuthOpts calls.