### PR TITLE
Fix the object download integration test

### DIFF
--- a/tests/integration/ObjectStore/V1Test.php
+++ b/tests/integration/ObjectStore/V1Test.php
@@ -2,9 +2,9 @@
 
 namespace OpenStack\Integration\ObjectStore;
 
-use GuzzleHttp\Stream\StreamInterface;
 use OpenStack\Integration\TestCase;
 use OpenStack\OpenStack;
+use Psr\Http\Message\StreamInterface;
 
 class V1Test extends TestCase
 {


### PR DESCRIPTION
The StreamInterface was changed in Guzzle6 and now it is using Psr\Http\Message\StreamInterface. The object download test now checks the result against this new interface instead of GuzzleHttp\Stream\StreamInterface.