### PR TITLE
Fix object store integration test

### DIFF
--- a/tests/integration/ObjectStore/V1Test.php
+++ b/tests/integration/ObjectStore/V1Test.php
@@ -195,6 +195,7 @@ class V1Test extends TestCase
 
         $this->logStep('Delete object');
         require_once $this->sampleFile($replacements, 'objects/delete.php');
+        $container->getObject($replacements['{newObjectName}'])->delete();
 
         $this->logStep('Delete container');
         $container->delete();


### PR DESCRIPTION
Container delete test failed because the container was not empty. This fix also delete the object created by the copy object step.