### PR TITLE
Fix v2 identity private property access bug

### DIFF
--- a/src/Identity/v2/Models/Entry.php
+++ b/src/Identity/v2/Models/Entry.php
@@ -12,13 +12,13 @@ use OpenStack\Common\Resource\AbstractResource;
 class Entry extends AbstractResource
 {
     /** @var string */
-    private $name;
+    public $name;
 
     /** @var string */
-    private $type;
+    public $type;
 
     /** @var []Endpoint */
-    private $endpoints = [];
+    public $endpoints = [];
 
     /**
      * Indicates whether this catalog entry matches a certain name and type.


### PR DESCRIPTION
The changeset 099ae8b210b3feaa2a1c259f336ac800a6ab9558 broke the v2 identity api, and caused a private property access issue on v2's Entry class. This patchset makes the private properties to
public to make it accessible from AbstractResource.populateFromArray() method.