### PR TITLE
Common/Transport/Utils.php: PHP7 JSON treats empty strings as syntax error

### DIFF
--- a/src/Common/Transport/Utils.php
+++ b/src/Common/Transport/Utils.php
@@ -18,7 +18,13 @@ class Utils
             JSON_ERROR_UTF8 => 'JSON_ERROR_UTF8 - Malformed UTF-8 characters, possibly incorrectly encoded'
         ];
 
-        $data = json_decode((string) $response->getBody(), $assoc);
+        $responseBody = (string) $response->getBody();
+
+        if (strlen($responseBody) === 0) {
+            return $responseBody;
+        }
+
+        $data = json_decode($responseBody, $assoc);
 
         if (JSON_ERROR_NONE !== json_last_error()) {
             $last = json_last_error();


### PR DESCRIPTION
As per the changelog entry at
https://github.com/php/php-src/commit/9d037d574cc359405c7a818c2235644633705999,
PHP7 treats empty-string equivalents as syntax error, as they are not
valid JSON. Special-case this in the json_decode path.

Signed-off-by: Nishanth Aravamudan <nish.aravamudan@canonical.com>