### PR TITLE
[wip] Guzzle request options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php-opencloud/common": "~1.0"
+        "php-opencloud/common": "^1.0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
@@ -33,6 +33,6 @@
         "psr/log": "~1.0",
         "satooshi/php-coveralls": "~1.0",
         "jakub-onderka/php-parallel-lint": "0.*",
-        "fabpot/php-cs-fixer": "~1.0"
+        "friendsofphp/php-cs-fixer": "^1.0"
     }
 }

--- a/src/OpenStack.php
+++ b/src/OpenStack.php
@@ -30,7 +30,7 @@ class OpenStack
      *         ['debugLog']         = (bool)              Whether to enable HTTP logging [OPTIONAL]
      *         ['logger']           = (LoggerInterface)   Must set if debugLog is true   [OPTIONAL]
      *         ['messageFormatter'] = (MessageFormatter)  Must set if debugLog is true   [OPTIONAL]
-     *         ['requestOption']    = (array)             Guzzle Http request options    [OPTIONAL]
+     *         ['requestOptions']   = (array)             Guzzle Http request options    [OPTIONAL]
      *
      * @param Builder $builder
      */

--- a/src/OpenStack.php
+++ b/src/OpenStack.php
@@ -20,7 +20,7 @@ class OpenStack
     private $builder;
 
     /**
-     * @param array $options User-defined options
+     * @param array    $options User-defined options
      *
      * $options['username']         = (string)            Your OpenStack username        [REQUIRED]
      *         ['password']         = (string)            Your OpenStack password        [REQUIRED]
@@ -30,6 +30,9 @@ class OpenStack
      *         ['debugLog']         = (bool)              Whether to enable HTTP logging [OPTIONAL]
      *         ['logger']           = (LoggerInterface)   Must set if debugLog is true   [OPTIONAL]
      *         ['messageFormatter'] = (MessageFormatter)  Must set if debugLog is true   [OPTIONAL]
+     *         ['requestOption']    = (array)             Guzzle Http request options    [OPTIONAL]
+     *
+     * @param Builder $builder
      */
     public function __construct(array $options = [], Builder $builder = null)
     {
@@ -51,10 +54,16 @@ class OpenStack
             throw new \InvalidArgumentException("'authUrl' is a required option");
         }
 
-        return Service::factory(new Client([
+        $clientOptions = [
             'base_uri' => Utils::normalizeUrl($options['authUrl']),
             'handler'  => HandlerStack::create(),
-        ]));
+        ];
+
+        if (isset($options['requestOptions'])) {
+            $clientOptions = array_merge($options['requestOptions'], $clientOptions);
+        }
+
+        return Service::factory(new Client($clientOptions));
     }
 
     /**


### PR DESCRIPTION
```php
$requestOptions = [
    'verify' => false,
    'headers' => ['User-Agent' => 'PHP-OPENCLOUD/SDKv1.0']
];

$params = [
    'authUrl' => 'http://172.16.113.139:5000/v3',
    'region'  => 'RegionOne',
    'user'    =>
        array(
            'name' => 'admin',
            'password' => '034cdbdb0fd84c5f',
            'domain'   =>
                array(
                    'id' => 'default',
                ),
        ),
    'requestOptions' => $requestOptions
];


$openstack = new OpenStack\OpenStack($params);

```