### PR TITLE
Also populate response from download

### DIFF
--- a/src/ObjectStore/v1/Models/Object.php
+++ b/src/ObjectStore/v1/Models/Object.php
@@ -101,6 +101,7 @@ class Object extends OperatorResource implements Creatable, Deletable, HasMetada
     public function download(): StreamInterface
     {
         $response = $this->executeWithState($this->api->getObject());
+        $this->populateFromResponse($response);
         return $response->getBody();
     }
 


### PR DESCRIPTION
Since a `download` also provides the `contentLength`, `hash`, `lastModified` etc. We should populate in order to prevent the requirement to execute multiple http requests while one is enough.