### PR TITLE
Allow postService() method to set description property

### DIFF
--- a/src/Identity/v3/Api.php
+++ b/src/Identity/v3/Api.php
@@ -61,6 +61,7 @@ class Api extends AbstractApi
             'params'  => [
                 'name' => $this->params->name('service'),
                 'type' => $this->params->type('service'),
+                'description' => $this->params->desc('service'),
             ]
         ];
     }

--- a/tests/integration/Identity/v3/CoreTest.php
+++ b/tests/integration/Identity/v3/CoreTest.php
@@ -147,7 +147,7 @@ class CoreTest extends TestCase
 
     public function endpoints()
     {
-        $service = $this->getService()->createService(['name' => $this->randomStr(), 'type' => 'volume']);
+        $service = $this->getService()->createService(['name' => $this->randomStr(), 'type' => 'volume', 'description' => $this->randomStr()]);
 
         $replacements = [
             '{endpointName}' => $this->randomStr(),

--- a/tests/unit/Identity/v3/Fixtures/service.resp
+++ b/tests/unit/Identity/v3/Fixtures/service.resp
@@ -6,6 +6,6 @@ Content-Type: application/json
         "id": "serviceId",
         "name": "foo",
         "type": "bar",
-        "description": "description",
+        "description": "description"
     }
 }

--- a/tests/unit/Identity/v3/Fixtures/service.resp
+++ b/tests/unit/Identity/v3/Fixtures/service.resp
@@ -5,6 +5,7 @@ Content-Type: application/json
     "service": {
         "id": "serviceId",
         "name": "foo",
-        "type": "bar"
+        "type": "bar",
+        "description": "description",
     }
 }

--- a/tests/unit/Identity/v3/ServiceTest.php
+++ b/tests/unit/Identity/v3/ServiceTest.php
@@ -157,7 +157,7 @@ class ServiceTest extends TestCase
 
     public function test_it_creates_service()
     {
-        $userOptions = ['name' => 'foo', 'type' => 'bar'];
+        $userOptions = ['name' => 'foo', 'type' => 'bar', 'description' => 'description'];
 
         $this->setupMock('POST', 'services', ['service' => $userOptions], [], 'service');
 


### PR DESCRIPTION
You cannot set `description` for a new service right now, I see the patchService() method have it, so I added it also for the creation.