### PR TITLE
[rfr] Add swift download options

### DIFF
--- a/src/ObjectStore/v1/Models/Object.php
+++ b/src/ObjectStore/v1/Models/Object.php
@@ -115,11 +115,14 @@ class Object extends OperatorResource implements Creatable, Deletable, HasMetada
 
     public function download(array $data = []): StreamInterface
     {
-        $response = $this->execute($this->api->getObject(), $data + ['containerName' => $this->containerName]);
+        $data += ['name' => $this->name, 'containerName' => $this->containerName];
+
+        /** @var ResponseInterface $response */
+        $response = $this->execute($this->api->getObject(), $data);
         $this->populateHeaders($response);
+
         return $response->getBody();
     }
-
 
     /**
      * {@inheritdoc}

--- a/src/ObjectStore/v1/Models/Object.php
+++ b/src/ObjectStore/v1/Models/Object.php
@@ -112,6 +112,7 @@ class Object extends OperatorResource implements Creatable, Deletable, HasMetada
      *
      * @return StreamInterface
      */
+
     public function download(array $data = []): StreamInterface
     {
         $response = $this->execute($this->api->getObject(), $data + ['containerName' => $this->containerName]);

--- a/src/ObjectStore/v1/Models/Object.php
+++ b/src/ObjectStore/v1/Models/Object.php
@@ -108,15 +108,17 @@ class Object extends OperatorResource implements Creatable, Deletable, HasMetada
      * distinct from fetching its metadata (a `HEAD` request). The body of an object is not fetched by default to
      * improve performance when handling large objects.
      *
+     * @param array $data {@see \OpenStack\ObjectStore\v1\Api::getObject}
+     *
      * @return StreamInterface
      */
-    public function download(): StreamInterface
+    public function download(array $data = []): StreamInterface
     {
-        /** @var ResponseInterface $response */
-        $response = $this->executeWithState($this->api->getObject());
+        $response = $this->execute($this->api->getObject(), $data + ['containerName' => $this->containerName]);
         $this->populateHeaders($response);
         return $response->getBody();
     }
+
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
This PR allows download options.

# Download the whole object
echo $obj->download()->getContents(); 

# Download only 0-20 bytes with modification time condition
echo $obj->download(['range' => 'bytes=0-20', 'ifModifiedSince' => 'Mon, 17 Jul 2017 07:28:00 ICT'])->getContents();  