### PR TITLE
Add power state and vm state to server model

### DIFF
--- a/src/Compute/v2/Models/Server.php
+++ b/src/Compute/v2/Models/Server.php
@@ -85,6 +85,12 @@ class Server extends OperatorResource implements
     /** @var string */
     public $taskState;
 
+    /** @var string */
+    public $powerState;
+
+    /** @var string */
+    public $vmState;
+
     protected $resourceKey = 'server';
     protected $resourcesKey = 'servers';
     protected $markerKey = 'id';
@@ -97,6 +103,8 @@ class Server extends OperatorResource implements
         'user_id'                             => 'userId',
         'security_groups'                     => 'securityGroups',
         'OS-EXT-STS:task_state'               => 'taskState',
+        'OS-EXT-STS:power_state'              => 'powerState',
+        'OS-EXT-STS:vm_state'                 => 'vmState',
         'OS-EXT-SRV-ATTR:hypervisor_hostname' => 'hypervisorHostname',
     ];
 


### PR DESCRIPTION
This PR adds the power state and the vm state of a server to the server model. Both are present in the API response (https://developer.openstack.org/api-ref/compute/#show-server-details) but currently not represented in the model.