### PR TITLE
Add server console output

### DIFF
--- a/samples/compute/v2/servers/get_server_console_output.php
+++ b/samples/compute/v2/servers/get_server_console_output.php
@@ -1,0 +1,20 @@
+<?php
+
+require 'vendor/autoload.php';
+
+$openstack = new OpenStack\OpenStack([
+    'authUrl' => '{authUrl}',
+    'region'  => '{region}',
+    'user'    => [
+        'id'       => '{userId}',
+        'password' => '{password}'
+    ],
+    'scope'   => ['project' => ['id' => '{projectId}']]
+]);
+
+$compute = $openstack->computeV2(['region' => '{region}']);
+
+$server = $compute->getServer(['id' => '{serverId}']);
+
+/** @var string $consoleOutput */
+$consoleOutput = $server->getConsoleOutput();

--- a/src/Compute/v2/Api.php
+++ b/src/Compute/v2/Api.php
@@ -372,6 +372,19 @@ class Api extends AbstractApi
         ];
     }
 
+    public function getConsoleOutput(): array
+    {
+        return [
+            'method'  => 'POST',
+            'path'    => 'servers/{id}/action',
+            'jsonKey' => 'os-getConsoleOutput',
+            'params'  => [
+                'id'     => $this->params->urlId('server'),
+                'length' => $this->notRequired($this->params->consoleLogLength()),
+            ],
+        ];
+    }
+
     public function createServerImage(): array
     {
         return [

--- a/src/Compute/v2/Api.php
+++ b/src/Compute/v2/Api.php
@@ -385,6 +385,18 @@ class Api extends AbstractApi
         ];
     }
 
+    public function getAllConsoleOutput(): array
+    {
+        return [
+            'method'  => 'POST',
+            'path'    => 'servers/{id}/action',
+            'params'  => [
+                'id'                  => $this->params->urlId('server'),
+                'os-getConsoleOutput' => $this->params->emptyObject(),
+            ],
+        ];
+    }
+
     public function createServerImage(): array
     {
         return [

--- a/src/Compute/v2/Models/Server.php
+++ b/src/Compute/v2/Models/Server.php
@@ -247,6 +247,22 @@ class Server extends OperatorResource implements
     }
 
     /**
+     * Gets the console output of the server.
+     *
+     * @param int $length The number of lines, by default all lines will be returned.
+     * @return string
+     */
+    public function getConsoleOutput(int $length = -1)
+    {
+        $response = $this->execute($this->api->getConsoleOutput(), [
+            'id' => $this->id,
+            'length' => $length
+        ]);
+
+        return Utils::jsonDecode($response)['output'];
+    }
+
+    /**
      * Gets a VNC console for a server.
      *
      * @param  string $type The type of VNC console: novnc|xvpvnc.

--- a/src/Compute/v2/Models/Server.php
+++ b/src/Compute/v2/Models/Server.php
@@ -252,7 +252,7 @@ class Server extends OperatorResource implements
      * @param int $length The number of lines, by default all lines will be returned.
      * @return string
      */
-    public function getConsoleOutput(int $length = -1)
+    public function getConsoleOutput(int $length = -1): string
     {
         $response = $this->execute($this->api->getConsoleOutput(), [
             'id' => $this->id,

--- a/src/Compute/v2/Models/Server.php
+++ b/src/Compute/v2/Models/Server.php
@@ -254,9 +254,12 @@ class Server extends OperatorResource implements
      */
     public function getConsoleOutput(int $length = -1): string
     {
-        $response = $this->execute($this->api->getConsoleOutput(), [
+        $definition = $length == -1 ? $this->api->getAllConsoleOutput() : $this->api->getConsoleOutput();
+
+        $response = $this->execute($definition, [
+            'os-getConsoleOutput' => new \stdClass(),
             'id' => $this->id,
-            'length' => $length
+            'length' => $length,
         ]);
 
         return Utils::jsonDecode($response)['output'];

--- a/src/Compute/v2/Params.php
+++ b/src/Compute/v2/Params.php
@@ -499,6 +499,15 @@ EOL
         ];
     }
 
+    public function consoleLogLength(): array
+    {
+        return [
+            'type'     => self::INT_TYPE,
+            'location' => self::JSON,
+            'required' => false,
+        ];
+    }
+
     protected function quotaSetLimit($sentAs, $description): array
     {
         return [

--- a/src/Compute/v2/Params.php
+++ b/src/Compute/v2/Params.php
@@ -508,6 +508,13 @@ EOL
         ];
     }
 
+    public function emptyObject(): array
+    {
+        return [
+            'type'  => self::OBJECT_TYPE,
+        ];
+    }
+
     protected function quotaSetLimit($sentAs, $description): array
     {
         return [

--- a/tests/integration/Compute/v2/CoreTest.php
+++ b/tests/integration/Compute/v2/CoreTest.php
@@ -703,4 +703,15 @@ class CoreTest extends TestCase
 
         $this->logStep('Create interface attachment for server {serverId}', $replacements);
     }
+
+    private function getConsoleOutput()
+    {
+        $replacements = [
+            '{serverId}' => $this->serverId
+        ];
+
+        require_once $this->sampleFile($replacements, 'servers/get_server_console_output.php');
+
+        $this->logStep('Get console output for server {serverId}', $replacements);
+    }
 }

--- a/tests/unit/Compute/v2/Fixtures/server-get-console-output.resp
+++ b/tests/unit/Compute/v2/Fixtures/server-get-console-output.resp
@@ -1,0 +1,6 @@
+HTTP/1.1 200 Accepted
+Content-Type: application/json
+
+{
+    "output": "FAKE CONSOLE OUTPUT\nANOTHER\nLAST LINE"
+}

--- a/tests/unit/Compute/v2/Models/ServerTest.php
+++ b/tests/unit/Compute/v2/Models/ServerTest.php
@@ -209,6 +209,14 @@ class ServerTest extends TestCase
         $this->assertNull($this->server->revertResize());
     }
 
+    public function test_it_gets_console_output()
+    {
+        $expectedJson = ["os-getConsoleOutput" => ["length" => 3]];
+        $this->setupMock('POST', 'servers/serverId/action', $expectedJson, [], 'server-get-console-output');
+
+        $this->assertEquals("FAKE CONSOLE OUTPUT\nANOTHER\nLAST LINE", $this->server->getConsoleOutput(3));
+    }
+
     public function test_it_gets_vnc_console()
     {
         $type = 'novnc';

--- a/tests/unit/Compute/v2/Models/ServerTest.php
+++ b/tests/unit/Compute/v2/Models/ServerTest.php
@@ -217,6 +217,14 @@ class ServerTest extends TestCase
         $this->assertEquals("FAKE CONSOLE OUTPUT\nANOTHER\nLAST LINE", $this->server->getConsoleOutput(3));
     }
 
+    public function test_it_gets_all_console_output()
+    {
+        $expectedJson = ["os-getConsoleOutput" => new \stdClass()];
+        $this->setupMock('POST', 'servers/serverId/action', $expectedJson, [], 'server-get-console-output');
+
+        $this->assertEquals("FAKE CONSOLE OUTPUT\nANOTHER\nLAST LINE", $this->server->getConsoleOutput());
+    }
+
     public function test_it_gets_vnc_console()
     {
         $type = 'novnc';


### PR DESCRIPTION
This PR adds the ability to get the console output of a server (see [OpenStack docs](https://developer.openstack.org/api-ref/compute/#show-console-output-os-getconsoleoutput-action) ).