### PR TITLE
Handle Datetime serialization

### DIFF
--- a/src/Common/Resource/AbstractResource.php
+++ b/src/Common/Resource/AbstractResource.php
@@ -178,7 +178,13 @@ abstract class AbstractResource implements ResourceInterface, Serializable
             $val = $this->{$name};
 
             $fn = function ($val) {
-                return ($val instanceof Serializable) ? $val->serialize() : $val;
+                if ($val instanceof Serializable) {
+                    return $val->serialize();
+                } elseif ($val instanceof \DateTimeImmutable) {
+                    return $val->format('c');
+                } else {
+                    return $val;
+                }
             };
 
             if (is_array($val)) {


### PR DESCRIPTION
The serialize method don't handle correctly `\DateTimeImmutable`

The unserialize method expect a string (\DateTimeImmutable constructor) 
```php
        } elseif (strcasecmp($type, '\datetimeimmutable') === 0) {
            $val = new \DateTimeImmutable($val);
```
But the serialize method serialize '\DateTimeImmutable' as object 
This throw an `DateTimeImmutable::__construct() expects parameter 1 to be string, object given` on calling `->populateFromArray((array) $serialize) `