### PR TITLE
Add `extra.branch-alias` in `composer.json` in order to allow dev version intalls respecting SemVer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,5 +50,10 @@
         "satooshi/php-coveralls": "~1.0",
         "jakub-onderka/php-parallel-lint": "0.*",
         "friendsofphp/php-cs-fixer": "^1.0"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
     }
 }


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |yes   |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |