### PR TITLE
Auth token caching

### DIFF
--- a/doc/services/identity/v3/tokens.rst
+++ b/doc/services/identity/v3/tokens.rst
@@ -50,18 +50,17 @@ Cache authentication token
 Use case
 ~~~~~~~~
 
-Before one can start calling any API, a very first step that this SDK will do is to authenticate with Identity service
-using user's credential.
+Before the SDK performs an API call, it will first authenticate to the OpenStack Identity service using the provided
+credentials.
 
-If the user's credential is valid, Identity service responses with an authentication token embedded in X-Auth-Token
-header and services catalog. The SDK will then use this authentication token and services catalog in all subsequent API
-calls.
+If the user's credential is valid, credentials are valid, the Identity service returns an authentication token. The SDK
+will then use this authentication token and service catalog in all subsequent API calls.
 
-This setup typically works well for command line type of applications. However, for web-based applications, performance
+This setup typically works well for CLI applications. However, for web-based applications, performance
 is undesirable since authentication step adds ~100ms to the response time.
 
-In order to improve performance, SDK allows users to export and store authentication token and re-use it when it is
-still valid.
+In order to improve performance, the SDK allows users to export and store authentication tokens, and re-use until they
+expire.
 
 
 Generate token and persist to file
@@ -71,7 +70,7 @@ Generate token and persist to file
 
 
 For scalability, it is recommended that cached tokens are stored in persistent storage such as memcache or redis instead
-of local file.
+of a local file.
 
 Initialize Open Stack using cached authentication token
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/services/identity/v3/tokens.rst
+++ b/doc/services/identity/v3/tokens.rst
@@ -43,3 +43,37 @@ Revoke token
 
 .. sample:: identity/v3/tokens/revoke_token.php
 .. refdoc:: OpenStack/Identity/v3/Service.html#method_revokeToken
+
+Cache authentication token
+--------------------------
+
+Use case
+~~~~~~~~
+
+Before one can start calling any API, a very first step that this SDK will do is to authenticate with Identity service
+using user's credential.
+
+If the user's credential is valid, Identity service responses with an authentication token embedded in X-Auth-Token
+header and services catalog. The SDK will then use this authentication token and services catalog in all subsequent API
+calls.
+
+This setup typically works well for command line type of applications. However, for web-based applications, performance
+is undesirable since authentication step adds ~100ms to the response time.
+
+In order to improve performance, SDK allows users to export and store authentication token and re-use it when it is
+still valid.
+
+
+Generate token and persist to file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. sample:: identity/v3/tokens/export_authentication_token.php
+
+
+For scalability, it is recommended that cached tokens are stored in persistent storage such as memcache or redis instead
+of local file.
+
+Initialize Open Stack using cached authentication token
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. sample:: identity/v3/tokens/use_cached_authentication_token.php

--- a/samples/identity/v3/tokens/export_authentication_token.php
+++ b/samples/identity/v3/tokens/export_authentication_token.php
@@ -30,4 +30,6 @@ file_put_contents('token.json', json_encode($token->export()));
 
 // Alternatively, one may persist token to memcache or redis
 // Redis and memcache then can purge the entry when token expires.
+
+/**@var \Memcached $memcache */
 $memcache->set('token', $token->export(), $token->expires->format('U'));

--- a/samples/identity/v3/tokens/export_authentication_token.php
+++ b/samples/identity/v3/tokens/export_authentication_token.php
@@ -30,4 +30,4 @@ file_put_contents('token.json', json_encode($token->export()));
 
 // Alternatively, one may persist token to memcache or redis
 // Redis and memcache then can purge the entry when token expires.
-$memcache->set('token', $token->export, $token->expires->format('U'));
+$memcache->set('token', $token->export(), $token->expires->format('U'));

--- a/samples/identity/v3/tokens/export_authentication_token.php
+++ b/samples/identity/v3/tokens/export_authentication_token.php
@@ -1,0 +1,33 @@
+<?php
+
+require 'vendor/autoload.php';
+
+$params = [
+    'authUrl' => '{authUrl}',
+    'region'  => '{region}',
+    'user'    => [
+        'name'     => '{username}',
+        'password' => '{password}',
+        'domain'   => ['id' => '{domainId}']
+    ],
+    'scope' => [
+        'project' => ['id' => '{projectId}']
+    ]
+];
+
+$openstack = new OpenStack\OpenStack($params);
+
+$identity = $openstack->identityV3();
+
+$token = $identity->generateToken($params);
+
+// Display token expiry
+echo sprintf('Token expires at %s'. PHP_EOL, $token->expires->format('c'));
+
+// Save token to file
+file_put_contents('token.json', json_encode($token->export()));
+
+
+// Alternatively, one may persist token to memcache or redis
+// Redis and memcache then can purge the entry when token expires.
+$memcache->set('token', $token->export, $token->expires->format('U'));

--- a/samples/identity/v3/tokens/use_cached_authentication_token.php
+++ b/samples/identity/v3/tokens/use_cached_authentication_token.php
@@ -2,8 +2,6 @@
 
 require 'vendor/autoload.php';
 
-
-
 $params = [
     'authUrl' => '{authUrl}',
     'region'  => '{region}',

--- a/samples/identity/v3/tokens/use_cached_authentication_token.php
+++ b/samples/identity/v3/tokens/use_cached_authentication_token.php
@@ -1,0 +1,27 @@
+<?php
+
+require 'vendor/autoload.php';
+
+
+
+$params = [
+    'authUrl' => '{authUrl}',
+    'region'  => '{region}',
+    'user'    => [
+        'name'     => '{username}',
+        'password' => '{password}',
+        'domain'   => ['id' => '{domainId}']
+    ],
+    'scope' => [
+        'project' => ['id' => '{projectId}']
+    ]
+];
+
+$token = json_decode(file_get_contents('token.json'), true);
+
+// Inject cached token to params if token is still fresh
+if ((new \DateTimeImmutable($token['expires_at'])) > (new \DateTimeImmutable('now'))) {
+    $params['cachedToken'] = $token;
+}
+
+$openstack = new OpenStack\OpenStack($params);

--- a/src/Identity/v3/Models/Token.php
+++ b/src/Identity/v3/Models/Token.php
@@ -121,11 +121,8 @@ class Token extends OperatorResource implements Creatable, Retrievable, \OpenSta
         $response = $this->execute($this->api->postTokens(), $data);
         $token = $this->populateFromResponse($response);
 
-
-        /**
-         * Cache response as an array to export if needed.
-         *  Added key `id` which is auth token from HTTP header X-Subject-Token
-         */
+        // Cache response as an array to export if needed.
+        // Added key `id` which is auth token from HTTP header X-Subject-Token
         $this->cachedToken = Utils::flattenJson(Utils::jsonDecode($response), $this->resourceKey);
         $this->cachedToken['id'] = $token->id;
 
@@ -133,7 +130,7 @@ class Token extends OperatorResource implements Creatable, Retrievable, \OpenSta
     }
 
     /**
-     * Retrieves an array serializable representation of authentication token.
+     * Returns a serialized representation of an authentication token.
      *
      * Initialize OpenStack object using $params['cachedToken'] to reduce HTTP authentication call.
      *

--- a/src/Identity/v3/Models/Token.php
+++ b/src/Identity/v3/Models/Token.php
@@ -132,9 +132,9 @@ class Token extends OperatorResource implements Creatable, Retrievable, \OpenSta
     /**
      * Returns a serialized representation of an authentication token.
      *
-     * Initialize OpenStack object using $params['cachedToken'] to reduce HTTP authentication call.
+     * Initialize OpenStack object using $params['cachedToken'] to reduce the amount of HTTP calls.
      *
-     * This array is a modified version of POST response to `auth/tokens`. Do not manually modify this array.
+     * This array is a modified version of response from `/auth/tokens`. Do not manually modify this array.
      *
      * @return array
      */

--- a/src/Identity/v3/Models/Token.php
+++ b/src/Identity/v3/Models/Token.php
@@ -44,7 +44,7 @@ class Token extends OperatorResource implements Creatable, Retrievable, \OpenSta
     protected $resourceKey = 'token';
     protected $resourcesKey = 'tokens';
 
-    protected $cacheCredential;
+    protected $cachedToken;
 
     /**
      * @inheritdoc
@@ -121,20 +121,28 @@ class Token extends OperatorResource implements Creatable, Retrievable, \OpenSta
         $response = $this->execute($this->api->postTokens(), $data);
         $token = $this->populateFromResponse($response);
 
-        $this->cacheCredential = Utils::flattenJson(Utils::jsonDecode($response), $this->resourceKey);
-        $this->cacheCredential['id'] = $token->id;
+
+        /**
+         * Cache response as an array to export if needed.
+         *  Added key `id` which is auth token from HTTP header X-Subject-Token
+         */
+        $this->cachedToken = Utils::flattenJson(Utils::jsonDecode($response), $this->resourceKey);
+        $this->cachedToken['id'] = $token->id;
 
         return $token;
     }
 
     /**
      * Retrieves an array serializable representation of authentication token.
-     * Can be use to initialise OpenStack object using $params['cachedCredential']
+     *
+     * Initialize OpenStack object using $params['cachedToken'] to reduce HTTP authentication call.
+     *
+     * This array is a modified version of POST response to `auth/tokens`. Do not manually modify this array.
      *
      * @return array
      */
-    public function exportCredential(): array
+    public function export(): array
     {
-        return $this->cacheCredential;
+        return $this->cachedToken;
     }
 }

--- a/src/Identity/v3/Service.php
+++ b/src/Identity/v3/Service.php
@@ -31,7 +31,11 @@ class Service extends AbstractService implements IdentityService
     {
         $authOptions = array_intersect_key($options, $this->api->postTokens()['params']);
 
-        $token = $this->generateToken($authOptions);
+        if (!empty($options['cachedCredential'])) {
+            $token = $this->generateTokenFromCache($options['cachedCredential']);
+        } else {
+            $token = $this->generateToken($authOptions);
+        }
 
         $name      = $options['catalogName'];
         $type      = $options['catalogType'];
@@ -44,6 +48,11 @@ class Service extends AbstractService implements IdentityService
 
         throw new \RuntimeException(sprintf("No service found with type [%s] name [%s] region [%s] interface [%s]",
             $type, $name, $region, $interface));
+    }
+
+    public function generateTokenFromCache(array $cache): Models\Token
+    {
+        return $this->model(Models\Token::class)->populateFromArray($cache);
     }
 
     /**

--- a/src/Identity/v3/Service.php
+++ b/src/Identity/v3/Service.php
@@ -35,7 +35,7 @@ class Service extends AbstractService implements IdentityService
             $token = $this->generateTokenFromCache($options['cachedToken']);
 
             if ($token->hasExpired()) {
-                throw new \RuntimeException(sprintf('Cached token has expired. You may need to re-generate a new token.'));
+                throw new \RuntimeException(sprintf('Cached token has expired on "%s".', $token->expires->format(\DateTime::ISO8601)));
             }
         } else {
             $token = $this->generateToken($authOptions);

--- a/src/Identity/v3/Service.php
+++ b/src/Identity/v3/Service.php
@@ -60,7 +60,6 @@ class Service extends AbstractService implements IdentityService
      * @param array $cachedToken {@see \OpenStack\Identity\v3\Models\Token::export}
      *
      * @return Models\Token
-     *
      */
     public function generateTokenFromCache(array $cachedToken): Models\Token
     {

--- a/src/OpenStack.php
+++ b/src/OpenStack.php
@@ -31,6 +31,7 @@ class OpenStack
      *         ['logger']           = (LoggerInterface)   Must set if debugLog is true   [OPTIONAL]
      *         ['messageFormatter'] = (MessageFormatter)  Must set if debugLog is true   [OPTIONAL]
      *         ['requestOptions']   = (array)             Guzzle Http request options    [OPTIONAL]
+     *         ['cachedCredential'] = (array)             Cached token credential        [OPTIONAL]
      *
      * @param Builder $builder
      */

--- a/src/OpenStack.php
+++ b/src/OpenStack.php
@@ -31,7 +31,7 @@ class OpenStack
      *         ['logger']           = (LoggerInterface)   Must set if debugLog is true   [OPTIONAL]
      *         ['messageFormatter'] = (MessageFormatter)  Must set if debugLog is true   [OPTIONAL]
      *         ['requestOptions']   = (array)             Guzzle Http request options    [OPTIONAL]
-     *         ['cachedCredential'] = (array)             Cached token credential        [OPTIONAL]
+     *         ['cachedToken']      = (array)             Cached token credential        [OPTIONAL]
      *
      * @param Builder $builder
      */

--- a/tests/unit/Identity/v3/ServiceTest.php
+++ b/tests/unit/Identity/v3/ServiceTest.php
@@ -10,9 +10,11 @@ use OpenStack\Identity\v3\Models;
 use OpenStack\Identity\v3\Service;
 use OpenStack\Test\TestCase;
 use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
 
 class ServiceTest extends TestCase
 {
+    /** @var Service */
     private $service;
 
     public function setUp()
@@ -511,6 +513,23 @@ class ServiceTest extends TestCase
 
         $token = $this->service->generateToken($userOptions);
         $this->assertInstanceOf(Models\Token::class, $token);
+    }
+
+    public function test_it_generates_token_from_cache()
+    {
+        $cache = [
+            'id' => 'some-token-id'
+        ];
+
+        $this->client
+            ->request('POST', 'auth/tokens', Argument::any())
+            ->shouldNotBeCalled()
+            ->willReturn($this->getFixture('token-get'));
+
+        $token = $this->service->generateTokenFromCache($cache);
+
+        $this->assertInstanceOf(Models\Token::class, $token);
+        $this->assertEquals('some-token-id', $token->id);
     }
 
     public function test_it_lists_endpoints()

--- a/tests/unit/Identity/v3/ServiceTest.php
+++ b/tests/unit/Identity/v3/ServiceTest.php
@@ -66,6 +66,156 @@ class ServiceTest extends TestCase
         $this->assertEquals('http://example.org:8080/v1/AUTH_e00abf65afca49609eedd163c515cf10', $url);
     }
 
+    public function test_it_authenticates_using_cache_token()
+    {
+        $cachedToken = [
+            'is_domain'  => false,
+            'methods'    => [
+                'password',
+            ],
+            'roles'      => [
+                0 => [
+                    'id'   => 'ce40dfb7a1b14f8a875194fe2944e00c',
+                    'name' => 'admin',
+                ],
+            ],
+            'expires_at' => '2199-11-24T04:47:49.000000Z',
+            'project'    => [
+                'domain' => [
+                    'id'   => 'default',
+                    'name' => 'Default',
+                ],
+                'id'     => 'c41b19de8aac4ecdb0f04ede718206c5',
+                'name'   => 'admin',
+            ],
+            'catalog' => [
+                [
+                    'endpoints' => [
+                        [
+                            'region_id' => 'RegionOne',
+                            'url'       => 'http://example.org:8080/v1/AUTH_e00abf65afca49609eedd163c515cf10',
+                            'region'    => 'RegionOne',
+                            'interface' => 'public',
+                            'id'        => 'hhh',
+                        ]
+                    ],
+                    'type'      => 'object-store',
+                    'id'        => 'aaa',
+                    'name'      => 'swift',
+                ],
+            ],
+            'user'       => [
+                'domain' => [
+                    'id'   => 'default',
+                    'name' => 'Default',
+                ],
+                'id'     => '37a36374b074428985165e80c9ab28c8',
+                'name'   => 'admin',
+            ],
+            'audit_ids'  => [
+                'X0oY7ouSQ32vEpbgDJTDpA',
+            ],
+            'issued_at'  => '2017-11-24T03:47:49.000000Z',
+            'id'         => 'bb4f74cfb73847ec9ca947fa61d799d3',
+        ];
+
+        $userOptions = [
+            'user'        => [
+                'id'       => '{userId}',
+                'password' => '{userPassword}',
+                'domain'   => ['id' => '{domainId}']
+            ],
+            'scope'       => [
+                'project' => ['id' => '{projectId}']
+            ],
+            'catalogName' => 'swift',
+            'catalogType' => 'object-store',
+            'region'      => 'RegionOne',
+            'cachedToken' => $cachedToken
+        ];
+
+        list($token, $url) = $this->service->authenticate($userOptions);
+
+        $this->assertInstanceOf(Models\Token::class, $token);
+        $this->assertEquals('http://example.org:8080/v1/AUTH_e00abf65afca49609eedd163c515cf10', $url);
+    }
+
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Cached token has expired
+     */
+    public function test_it_authenticates_and_throws_exception_when_authenticate_with_expired_cached_token()
+    {
+        $cachedToken = [
+            'is_domain'  => false,
+            'methods'    => [
+                'password',
+            ],
+            'roles'      => [
+                0 => [
+                    'id'   => 'ce40dfb7a1b14f8a875194fe2944e00c',
+                    'name' => 'admin',
+                ],
+            ],
+            'expires_at' => '2000-11-24T04:47:49.000000Z',
+            'project'    => [
+                'domain' => [
+                    'id'   => 'default',
+                    'name' => 'Default',
+                ],
+                'id'     => 'c41b19de8aac4ecdb0f04ede718206c5',
+                'name'   => 'admin',
+            ],
+            'catalog' => [
+                [
+                    'endpoints' => [
+                        [
+                            'region_id' => 'RegionOne',
+                            'url'       => 'http://example.org:8080/v1/AUTH_e00abf65afca49609eedd163c515cf10',
+                            'region'    => 'RegionOne',
+                            'interface' => 'public',
+                            'id'        => 'hhh',
+                        ]
+                    ],
+                    'type'      => 'object-store',
+                    'id'        => 'aaa',
+                    'name'      => 'swift',
+                ],
+            ],
+            'user'       => [
+                'domain' => [
+                    'id'   => 'default',
+                    'name' => 'Default',
+                ],
+                'id'     => '37a36374b074428985165e80c9ab28c8',
+                'name'   => 'admin',
+            ],
+            'audit_ids'  => [
+                'X0oY7ouSQ32vEpbgDJTDpA',
+            ],
+            'issued_at'  => '2017-11-24T03:47:49.000000Z',
+            'id'         => 'bb4f74cfb73847ec9ca947fa61d799d3',
+        ];
+
+        $userOptions = [
+            'user'        => [
+                'id'       => '{userId}',
+                'password' => '{userPassword}',
+                'domain'   => ['id' => '{domainId}']
+            ],
+            'scope'       => [
+                'project' => ['id' => '{projectId}']
+            ],
+            'catalogName' => 'swift',
+            'catalogType' => 'object-store',
+            'region'      => 'RegionOne',
+            'cachedToken' => $cachedToken
+        ];
+
+        $this->service->authenticate($userOptions);
+    }
+
     /**
      * @expectedException \RuntimeException
      */


### PR DESCRIPTION
Proof-of-concept re-use authentication token

Usage:

Export token
```php
<?php
// Export authentication credential
$params = [];
$openstack = new OpenStack\OpenStack($params);

$token = $openstack->identityV3()->generateToken($params);

 // This is an serializable array can be re-use
$cachedToken = $token->export();

// Save token to file
file_put_contents('cache.json', \json_encode($cachedToken));

// Or even better wrt scalability, store token in memcache
$memcache->set('array', $cachedToken, $expiration);

```


Use exported token
```php
// Authenticate using cache credential
$cachedToken = \json_decode(file_get_contents('cache.json'), true);

// params need to have all other mandatory fields such as `authUrl`, `user`, etc..
$params = [
  'cachedToken' => $cachedToken
]; 

$openstack = new OpenStack\OpenStack($params);
```

Design concerns
- Token expiration is not validated. Possibly rely on `expires_at` flag to trigger re-auth
- Increase in memory usage since `$token` holds a copy of API response in order to export it when needed. Depends on the size of catalog, this increase could range from 5-10KB


