### PR TITLE
Specify micro version for Service Builder

### DIFF
--- a/src/Common/Service/Builder.php
+++ b/src/Common/Service/Builder.php
@@ -83,9 +83,6 @@ class Builder
 
         list($apiClass, $serviceClass) = $this->getClasses($namespace);
 
-        /** @var Client $client */
-        $client = $options['httpClient'];
-
         return new $serviceClass($options['httpClient'], new $apiClass());
     }
 
@@ -100,15 +97,11 @@ class Builder
                 $stack = $this->getStack($options['authHandler'], $token);
             }
 
-            $microversion = null;
-            if (isset($options['microversion'])) {
-                $microversion = $options['microversion'];
-            }
-            dump($microversion);
+            $microVersion = $options['microVersion'] ?? null;
 
             $this->addDebugMiddleware($options, $stack);
 
-            $options['httpClient'] = $this->httpClient($baseUrl, $stack, $microversion);
+            $options['httpClient'] = $this->httpClient($baseUrl, $stack, $options['catalogType'], $microVersion);
         }
     }
 
@@ -146,15 +139,15 @@ class Builder
         return $stack;
     }
 
-    private function httpClient(string $baseUrl, HandlerStack $stack, string $microversion = null): ClientInterface
+    private function httpClient(string $baseUrl, HandlerStack $stack, string $serviceType, string $microVersion = null): ClientInterface
     {
         $clientOptions = [
             'base_uri' => Utils::normalizeUrl($baseUrl),
             'handler'  => $stack,
         ];
 
-        if ($microversion) {
-            $clientOptions['headers']['X-OpenStack-Nova-API-Version'] = $microversion;
+        if ($microVersion) {
+            $clientOptions['headers']['OpenStack-API-Version'] = sprintf('%s %s', $serviceType, $microVersion);
         }
 
         if (isset($this->globalOptions['requestOptions'])) {

--- a/src/Compute/v2/Api.php
+++ b/src/Compute/v2/Api.php
@@ -600,7 +600,8 @@ class Api extends AbstractApi
             'method' => 'GET',
             'path'   => 'os-keypairs/{name}',
             'params' => [
-                'name' => $this->isRequired($this->params->keypairName())
+                'name' => $this->isRequired($this->params->keypairName()),
+                'userId' => $this->isRequired($this->params->userId())
             ],
         ];
     }
@@ -610,7 +611,9 @@ class Api extends AbstractApi
         return [
             'method' => 'GET',
             'path'   => 'os-keypairs',
-            'params' => [],
+            'params' => [
+                'userId' => $this->params->userId()
+            ],
         ];
     }
 

--- a/src/Compute/v2/Api.php
+++ b/src/Compute/v2/Api.php
@@ -601,7 +601,7 @@ class Api extends AbstractApi
             'path'   => 'os-keypairs/{name}',
             'params' => [
                 'name' => $this->isRequired($this->params->keypairName()),
-                'userId' => $this->isRequired($this->params->userId())
+                'userId' => $this->params->userId()
             ],
         ];
     }

--- a/src/Compute/v2/Models/Keypair.php
+++ b/src/Compute/v2/Models/Keypair.php
@@ -65,7 +65,7 @@ class Keypair extends OperatorResource implements Listable, Retrievable, Deletab
      */
     public function retrieve()
     {
-        $response = $this->execute($this->api->getKeypair(), ['name' => (string) $this->name]);
+        $response = $this->execute($this->api->getKeypair(), $this->getAttrs(['name', 'userId']));
         $this->populateFromResponse($response);
     }
 

--- a/src/Compute/v2/Params.php
+++ b/src/Compute/v2/Params.php
@@ -451,6 +451,15 @@ EOL
         ];
     }
 
+    public function userId(): array
+    {
+        return [
+            'type'     => self::STRING_TYPE,
+            'sentAs'   => 'user_id',
+            'location' => self::URL
+        ];
+    }
+
     public function flavorRam(): array
     {
         return [

--- a/src/Compute/v2/Params.php
+++ b/src/Compute/v2/Params.php
@@ -456,7 +456,7 @@ EOL
         return [
             'type'     => self::STRING_TYPE,
             'sentAs'   => 'user_id',
-            'location' => self::URL
+            'location' => self::QUERY
         ];
     }
 

--- a/src/OpenStack.php
+++ b/src/OpenStack.php
@@ -66,7 +66,7 @@ class OpenStack
 
         $clientOptions = [
             'base_uri' => Utils::normalizeUrl($options['authUrl']),
-            'handler'  => $stack
+            'handler'  => $stack,
         ];
 
         if (isset($options['requestOptions'])) {

--- a/tests/unit/Compute/v2/Fixtures/keypair-get.resp
+++ b/tests/unit/Compute/v2/Fixtures/keypair-get.resp
@@ -5,7 +5,7 @@ Content-Type: application/json
     "keypair": {
         "fingerprint": "44:fe:29:6e:23:14:b9:53:5b:65:82:58:1c:fe:5a:c3",
         "name": "keypair-test",
-        "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC1HTrHCbb9NawNLSV8N6tSa8i637+EC2dA+lsdHHfQlT54t+N0nHhJPlKWDLhc579j87vp6RDFriFJ/smsTnDnf64O12z0kBaJpJPH2zXrBkZFK6q2rmxydURzX/z0yLSCP77SFJ0fdXWH2hMsAusflGyryHGX20n+mZK6mDrxVzGxEz228dwQ5G7Az5OoZDWygH2pqPvKjkifRw0jwUKf3BbkP0QvANACOk26cv16mNFpFJfI1N3OC5lUsZQtKGR01ptJoWijYKccqhkAKuo902tg/qup58J5kflNm7I61sy1mJon6SGqNUSfoQagqtBH6vd/tU1jnlwZ03uUroAL",
+        "public_key": "ssh-rsa AAAAAAABBBBBBBBBCCCCCCCCCCC foo@bar.com",
         "user_id": "fake",
         "deleted": false,
         "created_at": "2014-05-07T12:06:13.681238",

--- a/tests/unit/Compute/v2/Models/KeypairTest.php
+++ b/tests/unit/Compute/v2/Models/KeypairTest.php
@@ -53,7 +53,29 @@ class KeypairTest extends TestCase
         $this->assertEquals('44:fe:29:6e:23:14:b9:53:5b:65:82:58:1c:fe:5a:c3', $this->keypair->fingerprint);
         $this->assertEquals(self::KEYPAIR_NAME, $this->keypair->name);
         $this->assertEquals(
-            'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC1HTrHCbb9NawNLSV8N6tSa8i637+EC2dA+lsdHHfQlT54t+N0nHhJPlKWDLhc579j87vp6RDFriFJ/smsTnDnf64O12z0kBaJpJPH2zXrBkZFK6q2rmxydURzX/z0yLSCP77SFJ0fdXWH2hMsAusflGyryHGX20n+mZK6mDrxVzGxEz228dwQ5G7Az5OoZDWygH2pqPvKjkifRw0jwUKf3BbkP0QvANACOk26cv16mNFpFJfI1N3OC5lUsZQtKGR01ptJoWijYKccqhkAKuo902tg/qup58J5kflNm7I61sy1mJon6SGqNUSfoQagqtBH6vd/tU1jnlwZ03uUroAL',
+            'ssh-rsa AAAAAAABBBBBBBBBCCCCCCCCCCC foo@bar.com',
+            $this->keypair->publicKey
+        );
+        $this->assertFalse($this->keypair->deleted);
+    }
+
+    public function test_it_retrieves_by_user_id()
+    {
+        $this->client
+            ->request('GET', 'os-keypairs/' . self::KEYPAIR_NAME, ['headers' => [], 'query' => ['user_id' => 'fake']])
+            ->shouldBeCalled()
+            ->willReturn($this->getFixture('keypair-get'));
+
+
+        $this->keypair->userId = 'fake';
+        $this->keypair->retrieve();
+
+        $this->assertEquals('1', $this->keypair->id);
+        $this->assertEquals('fake', $this->keypair->userId);
+        $this->assertEquals('44:fe:29:6e:23:14:b9:53:5b:65:82:58:1c:fe:5a:c3', $this->keypair->fingerprint);
+        $this->assertEquals(self::KEYPAIR_NAME, $this->keypair->name);
+        $this->assertEquals(
+            'ssh-rsa AAAAAAABBBBBBBBBCCCCCCCCCCC foo@bar.com',
             $this->keypair->publicKey
         );
         $this->assertFalse($this->keypair->deleted);


### PR DESCRIPTION
By default, for backward compatibility, OpenStack API chooses the minimum supported version.
This also means certain features won't be available until a specified version is set in API calls via header, e.g `OpenStack-API-Version: compute 2.17`;

This PR allows SDK users to specify micro-version of a given service.

Usage: 

```php
$compute = $openstack->computeV2(['microVersion' => '2.27']);
```

