### PR TITLE
Fix wrong example code of grandGroupRole in Identity/v3/Project

### DIFF
--- a/doc/services/identity/v3/projects.rst
+++ b/doc/services/identity/v3/projects.rst
@@ -64,7 +64,7 @@ List roles for project group
 Grant role to project group
 ---------------------------
 
-.. sample:: identity/v3/projects/grant_user_role.php
+.. sample:: identity/v3/projects/grant_group_role.php
 .. refdoc:: OpenStack/Identity/v3/Models/Project.html#method_grantGroupRole
 
 Check role for project group


### PR DESCRIPTION
The document references to wrong example file on grantGroupRole of Identity/v3/Project service.