### PR TITLE
Fixing Policy PATCH method

### DIFF
--- a/src/Identity/v3/Api.php
+++ b/src/Identity/v3/Api.php
@@ -816,6 +816,7 @@ class Api extends AbstractApi
         return [
             'method' => 'PATCH',
             'path'   => 'policies/{id}',
+            'jsonKey' => 'policy',
             'params' => [
                 'id'        => $this->params->idUrl('policy'),
                 'blob'      => $this->params->blob(),

--- a/tests/unit/Identity/v3/Models/PolicyTest.php
+++ b/tests/unit/Identity/v3/Models/PolicyTest.php
@@ -57,7 +57,7 @@ class PolicyTest extends TestCase
     {
         $this->policy->type = 'foo';
 
-        $this->setupMock('PATCH', 'policies/POLICY_ID', ['type' => 'foo'], [], 'policy');
+        $this->setupMock('PATCH', 'policies/POLICY_ID', ['policy' => ['type' => 'foo']], [], 'policy');
 
         $this->policy->update();
     }


### PR DESCRIPTION
Added missing `jsonKey` key on patchPolicy() method and fixed affected test.