### PR TITLE
Adding possibility to filter floating ips by TennantId

### DIFF
--- a/src/Networking/v2/Extensions/Layer3/Api.php
+++ b/src/Networking/v2/Extensions/Layer3/Api.php
@@ -34,7 +34,9 @@ class Api extends AbstractApi
         return [
             'method' => 'GET',
             'path'   => $this->pathPrefix . '/floatingips',
-            'params' => [],
+            'params' => [
+                'tenantId' => $this->params->queryTenantId(),
+            ],
         ];
     }
 

--- a/src/Networking/v2/Extensions/Layer3/Service.php
+++ b/src/Networking/v2/Extensions/Layer3/Service.php
@@ -44,7 +44,7 @@ class Service extends AbstractService
      */
     public function listFloatingIps(array $options = []): \Generator
     {
-        return $this->floatingIp()->enumerate($this->api->getFloatingIps(),$options);
+        return $this->floatingIp()->enumerate($this->api->getFloatingIps(), $options);
     }
 
     /**

--- a/src/Networking/v2/Extensions/Layer3/Service.php
+++ b/src/Networking/v2/Extensions/Layer3/Service.php
@@ -42,9 +42,9 @@ class Service extends AbstractService
     /**
      * @return \Generator
      */
-    public function listFloatingIps(): \Generator
+    public function listFloatingIps(array $options = []): \Generator
     {
-        return $this->floatingIp()->enumerate($this->api->getFloatingIps());
+        return $this->floatingIp()->enumerate($this->api->getFloatingIps(),$options);
     }
 
     /**


### PR DESCRIPTION
Adding possibility to get Floating Ips by Tennant Id in the function to list floating ips.

Example : 

$openstack->networkingV2ExtLayer3()
                    ->listFloatingIps(['tenantId' => 'tennantId']);