### PR TITLE
fix metadata header parsing

### DIFF
--- a/src/ObjectStore/v1/Models/MetadataTrait.php
+++ b/src/ObjectStore/v1/Models/MetadataTrait.php
@@ -11,9 +11,9 @@ trait MetadataTrait
         $metadata = [];
 
         foreach ($response->getHeaders() as $header => $value) {
-            $position = strpos($header, static::METADATA_PREFIX);
-            if ($position === 0) {
-                $metadata[ltrim($header, static::METADATA_PREFIX)] = $response->getHeader($header)[0];
+            if (0 === strpos($header, static::METADATA_PREFIX)) {
+                $name = substr($header, strlen(static::METADATA_PREFIX));
+                $metadata[$name] = $response->getHeader($header)[0];
             }
         }
 

--- a/tests/unit/ObjectStore/v1/Fixtures/HEAD_Object.resp
+++ b/tests/unit/ObjectStore/v1/Fixtures/HEAD_Object.resp
@@ -5,6 +5,7 @@ Last-Modified: Thu, 16 Jan 2014 21:12:31 GMT
 Etag: 451e372e48e0f6b1114fa0724aa79fa1
 X-Timestamp: 1389906751.73463
 X-Object-Meta-Book: GoodbyeColumbus
+X-Object-Meta-Manufacturer: Acme
 Content-Type: application/octet-stream
 X-Trans-Id: tx37ea34dcd1ed48ca9bc7d-0052d84b6f
 Date: Thu, 16 Jan 2014 21:13:19 GMT

--- a/tests/unit/ObjectStore/v1/Models/ObjectTest.php
+++ b/tests/unit/ObjectStore/v1/Models/ObjectTest.php
@@ -66,7 +66,10 @@ class ObjectTest extends TestCase
     {
         $this->setupMock('HEAD', self::CONTAINER . '/' . self::NAME, null, [], 'HEAD_Object');
 
-        $this->assertEquals(['Book' => 'GoodbyeColumbus'], $this->object->getMetadata());
+        $this->assertEquals([
+            'Book'         => 'GoodbyeColumbus',
+            'Manufacturer' => 'Acme',
+        ], $this->object->getMetadata());
     }
 
     public function test_Merge_Metadata()
@@ -74,8 +77,9 @@ class ObjectTest extends TestCase
         $this->setupMock('HEAD', self::CONTAINER . '/' . self::NAME, null, [], 'HEAD_Object');
 
         $headers = [
-            'X-Object-Meta-Author' => 'foo',
-            'X-Object-Meta-Book'   => 'GoodbyeColumbus',
+            'X-Object-Meta-Author'       => 'foo',
+            'X-Object-Meta-Book'         => 'GoodbyeColumbus',
+            'X-Object-Meta-Manufacturer' => 'Acme',
         ];
 
         $this->setupMock('POST', self::CONTAINER . '/' . self::NAME, null, $headers, 'NoContent');


### PR DESCRIPTION
Hello,

This PR fixes the followiong metadata parsing error :
```php
$mask = 'X-Object-Meta-';
$header = 'X-Object-Meta-Manufacturer';

echo ltrim($header, $mask); // "nufacturer"
```
See live example [here](https://3v4l.org/f9aLm).

Actually, `ltrim` does not replaces by the whole string but uses chars in the given mask instead, and stops when it encounter a char which is not in the mask.