### PR TITLE
Add 'subdir' as alias for 'name' in StorageObject

### DIFF
--- a/src/ObjectStore/v1/Models/StorageObject.php
+++ b/src/ObjectStore/v1/Models/StorageObject.php
@@ -47,6 +47,7 @@ class StorageObject extends OperatorResource implements Creatable, Deletable, Ha
     protected $aliases = [
         'bytes' => 'contentLength',
         'content_type' => 'contentType',
+        'subdir' => 'name',
     ];
 
     /**


### PR DESCRIPTION
When listing objects with `delimiter=/` the response for any sub directory will only contain `{"subdir": "folder/"}`

Without this alias there is no way get a list of sub directories (without listing *all* objects)