### PR TITLE
Parse nanosecond in time stamp returned by API

### DIFF
--- a/src/Common/Resource/Alias.php
+++ b/src/Common/Resource/Alias.php
@@ -55,7 +55,7 @@ class Alias
             // New version of Openstack may include nanoseconds in timestamp
             // Attempt to reduce to micoseconds precision
             $pattern = '/\.([0-9]*)/';
-            $cb = function (array $m){ return count($m) == 2? '.'.substr($matches[1],0,6) : null};
+            $cb = function (array $m){ return (count($m) == 2) ? '.'.substr($m[1],0,6): null; };
             $value = preg_replace_callback($pattern, $cb, $value);
             
             return new \DateTimeImmutable($value);

--- a/src/Common/Resource/Alias.php
+++ b/src/Common/Resource/Alias.php
@@ -51,6 +51,13 @@ class Alias
             }
             return $array;
         } elseif ($this->className === \DateTimeImmutable::class) {
+            
+            // New version of Openstack may include nanoseconds in timestamp
+            // Attempt to reduce to micoseconds precision
+            $pattern = '/\.([0-9]*)/';
+            $cb = function (array $m){ return count($m) == 2? '.'.substr($matches[1],0,6); : null};
+            $value = preg_replace_callback($pattern, $cb, $value);
+            
             return new \DateTimeImmutable($value);
         }
 

--- a/src/Common/Resource/Alias.php
+++ b/src/Common/Resource/Alias.php
@@ -51,13 +51,14 @@ class Alias
             }
             return $array;
         } elseif ($this->className === \DateTimeImmutable::class) {
-            
-            // New version of Openstack may include nanoseconds in timestamp
+            // Newer version of Openstack may include nanoseconds in timestamp
             // Attempt to reduce to micoseconds precision
             $pattern = '/\.([0-9]*)/';
-            $cb = function (array $m){ return (count($m) == 2) ? '.'.substr($m[1],0,6): null; };
+            $cb = function (array $m) {
+                return (count($m) == 2) ? '.'.substr($m[1], 0, 6): null;
+            };
             $value = preg_replace_callback($pattern, $cb, $value);
-            
+
             return new \DateTimeImmutable($value);
         }
 

--- a/src/Common/Resource/Alias.php
+++ b/src/Common/Resource/Alias.php
@@ -55,7 +55,7 @@ class Alias
             // New version of Openstack may include nanoseconds in timestamp
             // Attempt to reduce to micoseconds precision
             $pattern = '/\.([0-9]*)/';
-            $cb = function (array $m){ return count($m) == 2? '.'.substr($matches[1],0,6); : null};
+            $cb = function (array $m){ return count($m) == 2? '.'.substr($matches[1],0,6) : null};
             $value = preg_replace_callback($pattern, $cb, $value);
             
             return new \DateTimeImmutable($value);


### PR DESCRIPTION
PHP is not able to handle time precision beyond micro-second.

~~Unfortunately OpenStack API starts sending date time with nano-second precision.~~ 

This PR aims to fix the issue by just naively cut time decimal to 6 digits.

Update: looks like this is not an issue at all. The case reported was an go-lang adaptation and replacement of Swift API which implements some of the endpoints of Swift. 

