### PR TITLE
Fix number of segments of a large object

### DIFF
--- a/src/ObjectStore/v1/Models/Container.php
+++ b/src/ObjectStore/v1/Models/Container.php
@@ -226,10 +226,11 @@ class Container extends OperatorResource implements Creatable, Deletable, Retrie
             $service->createContainer(['name' => $segmentContainer]);
         }
 
-        $promises = [];
-        $count    = 0;
+        $promises      = [];
+        $count         = 0;
+        $totalSegments = $stream->getSize() / $segmentSize;
 
-        while (!$stream->eof() && $count < round($stream->getSize() / $segmentSize)) {
+        while (!$stream->eof() && $count < $totalSegments) {
             $promises[] = $this->model(StorageObject::class)->createAsync([
                 'name'          => sprintf('%s/%d', $segmentPrefix, ++$count),
                 'stream'        => new LimitStream($stream, $segmentSize, ($count - 1) * $segmentSize),

--- a/tests/unit/ObjectStore/v1/Models/ContainerTest.php
+++ b/tests/unit/ObjectStore/v1/Models/ContainerTest.php
@@ -213,7 +213,7 @@ class ContainerTest extends TestCase
     public function test_it_chunks_according_to_provided_segment_size()
     {
         /** @var \GuzzleHttp\Psr7\Stream $stream */
-        $stream = \GuzzleHttp\Psr7\stream_for(implode('', range('A', 'Z')));
+        $stream = \GuzzleHttp\Psr7\stream_for(implode('', range('A', 'X')));
 
         $data = [
             'name' => 'object',
@@ -235,6 +235,7 @@ class ContainerTest extends TestCase
 
         $this->setupMock('PUT', 'segments', null, [], new Response(201));
 
+        // The stream has size 24 so we expect three segments.
         $this->setupMock('PUT', 'segments/objectPrefix/1', $stream->read(10), [], new Response(201));
         $this->setupMock('PUT', 'segments/objectPrefix/2', $stream->read(10), [], new Response(201));
         $this->setupMock('PUT', 'segments/objectPrefix/3', $stream->read(10), [], new Response(201));


### PR DESCRIPTION
This fixes an off by one error with the number of segments of large objects uploaded to Swift.

The total number of segments was determined with `round($streamSize/$segmentSize)`. In cases like `$streamSize=24` and `$segmentSize=10` this resulted in one segment too few that was uploaded. This has been fixed by simply omitting `round()`. I also updated the test which did not fail before by pure chance.