### PR TITLE
Add parameter Network Fixed IP to instance creation

### DIFF
--- a/src/Compute/v2/Params.php
+++ b/src/Compute/v2/Params.php
@@ -299,6 +299,11 @@ To provision the server instance with a NIC for an already existing port, specif
 a networks object. The port status must be DOWN. Required if you omit the uuid attribute.
 EOL
                     ],
+                    'fixedIp' => [
+                        'type'        => self::STRING_TYPE,
+                        'description' => 'A fixed IPv4 address for the NIC. Valid with a neutron or nova-networks network.',
+                        'sentAs'      => 'fixed_ip',
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
To permit define Fixed Ip on instance creation.

```
$options = [
    'name'    => 'test',
    'imageId' => 'xxxxxxx',
    'flavorId' => 'xxxxxxxxxxxx',
    'blockDeviceMapping' => [[
        "bootIndex"       => 0,
        "uuid"            => 'xxxxxxxxxxxxxx',
        "sourceType"      => "image",
        "volumeSize"      => 20,
        "destinationType" => "volume",
        'deleteOnTermination' => true
    ]],
    'networks' => [
        [
            'uuid' => 'xxxxxxxxxxxxx',
            'fixedIp' => '10.0.0.254'
        ]
    ]
];

$openstack->computeV2()->createServer($options);
```