### PR TITLE
Fix "Missing header delimiter" errors of new GuzzleHttp version

### DIFF
--- a/tests/unit/Compute/v2/Fixtures/server-unrescue.resp
+++ b/tests/unit/Compute/v2/Fixtures/server-unrescue.resp
@@ -1,2 +1,3 @@
 HTTP/1.1 202 Accepted
 Content-Type: application/json
+

--- a/tests/unit/ObjectStore/v1/Fixtures/Created.resp
+++ b/tests/unit/ObjectStore/v1/Fixtures/Created.resp
@@ -5,3 +5,4 @@ Etag: d41d8cd98f00b204e9800998ecf8427e
 Content-Type: text/html; charset=UTF-8
 X-Trans-Id: tx4d5e4f06d357462bb732f-0052d96843
 Date: Fri, 17 Jan 2014 17:28:35 GMT
+

--- a/tests/unit/ObjectStore/v1/Fixtures/HEAD_Account.resp
+++ b/tests/unit/ObjectStore/v1/Fixtures/HEAD_Account.resp
@@ -10,3 +10,4 @@ Content-Type: text/plain; charset=utf-8
 Accept-Ranges: bytes
 X-Trans-Id: txafb3504870144b8ca40f7-0052d955d4
 Date: Fri, 17 Jan 2014 16:09:56 GMT
+

--- a/tests/unit/ObjectStore/v1/Fixtures/HEAD_Container.resp
+++ b/tests/unit/ObjectStore/v1/Fixtures/HEAD_Container.resp
@@ -9,3 +9,4 @@ X-Container-Bytes-Used: 14
 Content-Type: text/plain; charset=utf-8
 X-Trans-Id: tx0287b982a268461b9ec14-0052d826e2
 Date: Thu, 16 Jan 2014 18:37:22 GMT
+

--- a/tests/unit/ObjectStore/v1/Fixtures/HEAD_Object.resp
+++ b/tests/unit/ObjectStore/v1/Fixtures/HEAD_Object.resp
@@ -9,3 +9,4 @@ X-Object-Meta-Manufacturer: Acme
 Content-Type: application/octet-stream
 X-Trans-Id: tx37ea34dcd1ed48ca9bc7d-0052d84b6f
 Date: Thu, 16 Jan 2014 21:13:19 GMT
+

--- a/tests/unit/ObjectStore/v1/Fixtures/NoContent.resp
+++ b/tests/unit/ObjectStore/v1/Fixtures/NoContent.resp
@@ -3,3 +3,4 @@ Content-Length: 0
 Content-Type: text/html; charset=UTF-8
 X-Trans-Id: tx1439b96137364ab581156-0052d95532
 Date: Fri, 17 Jan 2014 16:07:14 GMT
+


### PR DESCRIPTION
A newer `guzzlehttp/psr7` version caused some unit tests to fail with `InvalidArgumentException: Invalid message: Missing header delimiter`. This PR adds the header delimiter to fix the tests.