### PR TITLE
ObjectStore: Allow "deleteAt" and "deleteAfter" parameters

### DIFF
--- a/src/ObjectStore/v1/Api.php
+++ b/src/ObjectStore/v1/Api.php
@@ -192,6 +192,8 @@ class Api extends AbstractApi
                 'contentEncoding'    => $this->params->contentEncoding(),
                 'metadata'           => $this->params->metadata('object'),
                 'freshMetadata'      => $this->params->freshMetadata(),
+                'deleteAt'           => $this->params->deleteAt(),
+                'deleteAfter'        => $this->params->deleteAfter(),
             ],
         ];
     }


### PR DESCRIPTION
Ensure the "deleteAt" and "deleteAfter" parameters are allowed when executing a "copyObject()".