### PR TITLE
Left-pad large object segment names with zeros.

### DIFF
--- a/src/ObjectStore/v1/Models/Container.php
+++ b/src/ObjectStore/v1/Models/Container.php
@@ -220,13 +220,15 @@ class Container extends OperatorResource implements Creatable, Deletable, Retrie
             $service->createContainer(['name' => $segmentContainer]);
         }
 
-        $promises      = [];
-        $count         = 0;
-        $totalSegments = $stream->getSize() / $segmentSize;
+        $promises          = [];
+        $count             = 0;
+        $totalSegments     = $stream->getSize() / $segmentSize;
+        $segmentNameLength = strlen( (string) $totalSegments) + 1;
+        $segmentNameFormat = sprintf('%%s/%%0%dd', $segmentNameLength);
 
         while (!$stream->eof() && $count < $totalSegments) {
             $promises[] = $this->model(StorageObject::class)->createAsync([
-                'name'          => sprintf('%s/%d', $segmentPrefix, ++$count),
+                'name'          => sprintf($segmentNameFormat, $segmentPrefix, ++$count),
                 'stream'        => new LimitStream($stream, $segmentSize, ($count - 1) * $segmentSize),
                 'containerName' => $segmentContainer,
             ]);


### PR DESCRIPTION
This fixes #318 by using a similar strategy as the official python command-line client. The segment name is left-padded with zeros so when the segment names are sorted on download they end up in the right order.

Instead of always using a length of 8 for the segment name like the command-line client, I checked the string length of the total number of segments, (which will be the name for the last segment), and added one. This way there's no client-imposed limit on the number of segments, at the expense of having to `sprintf()` twice.