### PR TITLE
Update phpunit and allow php8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
     - php: 7.2
     - php: 7.3
     - php: 7.4
+    - php: 8.0
     - php: nightly
   allow_failures:
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,10 @@ before_install:
 before_script:
   - composer install --prefer-source
   - vendor/bin/parallel-lint --exclude vendor .
-  - vendor/bin/php-cs-fixer fix --dry-run --diff
+
+  # Once php8 is officially supported by the cs-fixer, the env variable should be dropped
+  # Ref https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4702
+  - PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --diff
   - phpenv config-add ./xdebug.ini
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,7 @@ before_install:
 before_script:
   - composer install --prefer-source
   - vendor/bin/parallel-lint --exclude vendor .
-
-  # Once php8 is officially supported by the cs-fixer, the env variable should be dropped
-  # Ref https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4702
-  - PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --diff
+  - vendor/bin/php-cs-fixer fix --dry-run --diff
   - phpenv config-add ./xdebug.ini
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-sudo: false
-
 dist: bionic
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,8 @@
         "phpunit/phpunit": "^6.5",
         "psr/log": "^1.0",
         "php-coveralls/php-coveralls": "^2.0",
-        "jakub-onderka/php-parallel-lint": "^1.0",
-        "friendsofphp/php-cs-fixer": "^2.13"
+        "friendsofphp/php-cs-fixer": "^2.13",
+        "php-parallel-lint/php-parallel-lint": "^1.2"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpunit/phpunit": "^8.0",
         "psr/log": "^1.0",
         "php-coveralls/php-coveralls": "^2.0",
-        "friendsofphp/php-cs-fixer": "^2.17",
+        "friendsofphp/php-cs-fixer": "^2.18",
         "php-parallel-lint/php-parallel-lint": "^1.2"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpunit/phpunit": "^8.0",
         "psr/log": "^1.0",
         "php-coveralls/php-coveralls": "^2.0",
-        "friendsofphp/php-cs-fixer": "^2.13",
+        "friendsofphp/php-cs-fixer": "^2.17",
         "php-parallel-lint/php-parallel-lint": "^1.2"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -33,13 +33,13 @@
         }
     },
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "guzzlehttp/guzzle": "^7.0",
         "guzzlehttp/uri-template": "0.2",
         "justinrainbow/json-schema": "^5.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5",
+        "phpunit/phpunit": "^8.0",
         "psr/log": "^1.0",
         "php-coveralls/php-coveralls": "^2.0",
         "friendsofphp/php-cs-fixer": "^2.13",

--- a/src/Common/Transport/Middleware.php
+++ b/src/Common/Transport/Middleware.php
@@ -20,7 +20,7 @@ final class Middleware
         return function (callable $handler) {
             return function ($request, array $options) use ($handler) {
                 return $handler($request, $options)->then(
-                    function (ResponseInterface $response) use ($request, $handler) {
+                    function (ResponseInterface $response) use ($request) {
                         if ($response->getStatusCode() < 400) {
                             return $response;
                         }

--- a/src/OpenStack.php
+++ b/src/OpenStack.php
@@ -77,7 +77,7 @@ class OpenStack
      *
      * @param array $options options that will be used in configuring the service
      */
-    public function computeV2(array $options = []): \OpenStack\Compute\v2\Service
+    public function computeV2(array $options = []): Compute\v2\Service
     {
         $defaults = ['catalogName' => 'nova', 'catalogType' => 'compute'];
 
@@ -89,7 +89,7 @@ class OpenStack
      *
      * @param array $options options that will be used in configuring the service
      */
-    public function networkingV2(array $options = []): \OpenStack\Networking\v2\Service
+    public function networkingV2(array $options = []): Networking\v2\Service
     {
         $defaults = ['catalogName' => 'neutron', 'catalogType' => 'network'];
 
@@ -101,7 +101,7 @@ class OpenStack
      *
      * @param array $options options that will be used in configuring the service
      */
-    public function networkingV2ExtLayer3(array $options = []): \OpenStack\Networking\v2\Extensions\Layer3\Service
+    public function networkingV2ExtLayer3(array $options = []): Networking\v2\Extensions\Layer3\Service
     {
         $defaults = ['catalogName' => 'neutron', 'catalogType' => 'network'];
 
@@ -113,7 +113,7 @@ class OpenStack
      *
      * @param array $options options that will be used in configuring the service
      */
-    public function networkingV2ExtSecGroups(array $options = []): \OpenStack\Networking\v2\Extensions\SecurityGroups\Service
+    public function networkingV2ExtSecGroups(array $options = []): Networking\v2\Extensions\SecurityGroups\Service
     {
         $defaults = ['catalogName' => 'neutron', 'catalogType' => 'network'];
 
@@ -125,7 +125,7 @@ class OpenStack
      *
      * @param array $options options that will be used in configuring the service
      */
-    public function identityV2(array $options = []): \OpenStack\Identity\v2\Service
+    public function identityV2(array $options = []): Identity\v2\Service
     {
         $defaults = ['catalogName' => 'keystone', 'catalogType' => 'identity'];
 
@@ -137,7 +137,7 @@ class OpenStack
      *
      * @param array $options options that will be used in configuring the service
      */
-    public function identityV3(array $options = []): \OpenStack\Identity\v3\Service
+    public function identityV3(array $options = []): Service
     {
         $defaults = ['catalogName' => 'keystone', 'catalogType' => 'identity'];
 
@@ -149,7 +149,7 @@ class OpenStack
      *
      * @param array $options options that will be used in configuring the service
      */
-    public function objectStoreV1(array $options = []): \OpenStack\ObjectStore\v1\Service
+    public function objectStoreV1(array $options = []): ObjectStore\v1\Service
     {
         $defaults = ['catalogName' => 'swift', 'catalogType' => 'object-store'];
 
@@ -161,7 +161,7 @@ class OpenStack
      *
      * @param array $options options that will be used in configuring the service
      */
-    public function blockStorageV2(array $options = []): \OpenStack\BlockStorage\v2\Service
+    public function blockStorageV2(array $options = []): BlockStorage\v2\Service
     {
         $defaults = ['catalogName' => 'cinderv2', 'catalogType' => 'volumev2'];
 
@@ -173,7 +173,7 @@ class OpenStack
      *
      * @param array $options options that will be used in configuring the service
      */
-    public function imagesV2(array $options = []): \OpenStack\Images\v2\Service
+    public function imagesV2(array $options = []): Images\v2\Service
     {
         $defaults = ['catalogName' => 'glance', 'catalogType' => 'image'];
 
@@ -183,7 +183,7 @@ class OpenStack
     /**
      * Creates a new Gnocchi Metric service v1.
      */
-    public function metricGnocchiV1(array $options = []): \OpenStack\Metric\v1\Gnocchi\Service
+    public function metricGnocchiV1(array $options = []): Metric\v1\Gnocchi\Service
     {
         $defaults = ['catalogName' => 'gnocchi', 'catalogType' => 'metric'];
 

--- a/tests/integration/BlockStorage/v2/CoreTest.php
+++ b/tests/integration/BlockStorage/v2/CoreTest.php
@@ -55,10 +55,10 @@ class CoreTest extends TestCase
         $this->logStep('Creating volume');
         /** @var Volume $volume */
         require_once $this->sampleFile($replacements, 'volumes/create.php');
-        $this->assertInstanceOf(Volume::class, $volume);
-        $this->assertEquals($replacements['{name}'], $volume->name);
-        $this->assertEquals(1, $volume->size);
-        $this->assertEquals($volumeType->name, $volume->volumeTypeName);
+        self::assertInstanceOf(Volume::class, $volume);
+        self::assertEquals($replacements['{name}'], $volume->name);
+        self::assertEquals(1, $volume->size);
+        self::assertEquals($volumeType->name, $volume->volumeTypeName);
 
         $volumeId = $volume->id;
         $replacements = ['{volumeId}' => $volumeId];
@@ -66,14 +66,14 @@ class CoreTest extends TestCase
         $this->logStep('Getting volume');
         /** @var Volume $volume */
         require_once $this->sampleFile($replacements, 'volumes/get.php');
-        $this->assertInstanceOf(Volume::class, $volume);
+        self::assertInstanceOf(Volume::class, $volume);
 
         $replacements += ['{newName}' => $this->randomStr(), '{newDescription}' => $this->randomStr()];
 
         $this->logStep('Updating volume');
         /** @var Volume $volume */
         require_once $this->sampleFile($replacements, 'volumes/update.php');
-        $this->assertInstanceOf(Volume::class, $volume);
+        self::assertInstanceOf(Volume::class, $volume);
 
         $this->logStep('Listing volumes');
         /** @var \Generator $volumes */
@@ -98,22 +98,22 @@ class CoreTest extends TestCase
         $this->logStep('Creating volume type');
         /** @var VolumeType $volumeType */
         require_once $this->sampleFile($replacements, 'volume_types/create.php');
-        $this->assertInstanceOf(VolumeType::class, $volumeType);
-        $this->assertEquals($replacements['{name}'], $volumeType->name);
+        self::assertInstanceOf(VolumeType::class, $volumeType);
+        self::assertEquals($replacements['{name}'], $volumeType->name);
 
         $replacements = ['{volumeTypeId}' => $volumeType->id];
 
         $this->logStep('Getting volume type');
         /** @var VolumeType $volumeType */
         require_once $this->sampleFile($replacements, 'volume_types/get.php');
-        $this->assertInstanceOf(VolumeType::class, $volumeType);
+        self::assertInstanceOf(VolumeType::class, $volumeType);
 
         $replacements += ['{newName}' => $this->randomStr()];
 
         $this->logStep('Updating volume type');
         /** @var VolumeType $volumeType */
         require_once $this->sampleFile($replacements, 'volume_types/update.php');
-        $this->assertInstanceOf(VolumeType::class, $volumeType);
+        self::assertInstanceOf(VolumeType::class, $volumeType);
 
         $this->logStep('Listing volume types');
         /** @var \Generator $volumeTypes */
@@ -138,8 +138,8 @@ class CoreTest extends TestCase
         $this->logStep('Creating snapshot');
         /** @var Snapshot $snapshot */
         require_once $this->sampleFile($replacements, 'snapshots/create.php');
-        $this->assertInstanceOf(Snapshot::class, $snapshot);
-        $this->assertEquals($replacements['{name}'], $snapshot->name);
+        self::assertInstanceOf(Snapshot::class, $snapshot);
+        self::assertEquals($replacements['{name}'], $snapshot->name);
         $volume->waitUntil('available', 60);
 
         $snapshotId = $snapshot->id;
@@ -148,7 +148,7 @@ class CoreTest extends TestCase
         $this->logStep('Getting snapshot');
         /** @var Snapshot $snapshot */
         require_once $this->sampleFile($replacements, 'snapshots/get.php');
-        $this->assertInstanceOf(Snapshot::class, $snapshot);
+        self::assertInstanceOf(Snapshot::class, $snapshot);
 
         $this->getService()
             ->getSnapshot($snapshot->id)
@@ -161,7 +161,7 @@ class CoreTest extends TestCase
         $this->logStep('Retrieving metadata');
         /** @var array $metadata */
         require_once $this->sampleFile($replacements, 'snapshots/get_metadata.php');
-        $this->assertEquals(['key1' => 'val1', 'key2' => 'val2'], $metadata);
+        self::assertEquals(['key1' => 'val1', 'key2' => 'val2'], $metadata);
 
         $replacements = ['{snapshotId}' => $snapshot->id, '{key}' => 'key3', '{val}' => 'val3'];
         $this->logStep('Resetting metadata');
@@ -170,7 +170,7 @@ class CoreTest extends TestCase
         $this->logStep('Retrieving metadata');
         /** @var array $metadata */
         require_once $this->sampleFile($replacements, 'snapshots/get_metadata.php');
-        $this->assertEquals(['key3' => 'val3'], $metadata);
+        self::assertEquals(['key3' => 'val3'], $metadata);
 
         $replacements += ['{newName}' => $this->randomStr(), '{newDescription}' => $this->randomStr()];
         $this->logStep('Updating snapshot');

--- a/tests/integration/Compute/v2/CoreTest.php
+++ b/tests/integration/Compute/v2/CoreTest.php
@@ -247,9 +247,9 @@ class CoreTest extends TestCase
 
         $server->waitUntilActive(false);
 
-        $this->assertInstanceOf('OpenStack\Compute\v2\Models\Server', $server);
-        $this->assertNotEmpty($server->id);
-        $this->assertNotEmpty($server->adminPass);
+        self::assertInstanceOf('OpenStack\Compute\v2\Models\Server', $server);
+        self::assertNotEmpty($server->id);
+        self::assertNotEmpty($server->adminPass);
 
         $this->serverId = $server->id;
         $this->adminPass = $server->adminPass;
@@ -270,8 +270,8 @@ class CoreTest extends TestCase
         $path = $this->sampleFile($replacements, 'servers/update_server.php');
         require_once $path;
 
-        $this->assertInstanceOf('OpenStack\Compute\v2\Models\Server', $server);
-        $this->assertEquals($name, $server->name);
+        self::assertInstanceOf('OpenStack\Compute\v2\Models\Server', $server);
+        self::assertEquals($name, $server->name);
 
         $server->waitUntilActive(false);
 
@@ -299,15 +299,15 @@ class CoreTest extends TestCase
         $path = $this->sampleFile($replacements, 'servers/get_server.php');
         require_once $path;
 
-        $this->assertInstanceOf('OpenStack\Compute\v2\Models\Server', $server);
-        $this->assertEquals($this->serverId, $server->id);
-        $this->assertNotNull($server->created);
-        $this->assertNotNull($server->updated);
-        $this->assertNotNull($server->name);
-        $this->assertNotNull($server->ipv4);
-        $this->assertNotNull($server->status);
-        $this->assertInstanceOf(Image::class, $server->image);
-        $this->assertInstanceOf(Flavor::class, $server->flavor);
+        self::assertInstanceOf('OpenStack\Compute\v2\Models\Server', $server);
+        self::assertEquals($this->serverId, $server->id);
+        self::assertNotNull($server->created);
+        self::assertNotNull($server->updated);
+        self::assertNotNull($server->name);
+        self::assertNotNull($server->ipv4);
+        self::assertNotNull($server->status);
+        self::assertInstanceOf(Image::class, $server->image);
+        self::assertInstanceOf(Flavor::class, $server->flavor);
 
         $this->logStep('Retrieved the details of server ID', ['ID' => $this->serverId]);
     }
@@ -456,7 +456,7 @@ class CoreTest extends TestCase
         $path = $this->sampleFile($replacements, 'flavors/create_flavor.php');
         require_once $path;
 
-        $this->assertInstanceOf('\OpenStack\Compute\v2\Models\Flavor', $flavor);
+        self::assertInstanceOf('\OpenStack\Compute\v2\Models\Flavor', $flavor);
 
         $this->flavorId = $flavor->id;
         $this->logStep('Created flavor {id}', ['{id}' => $flavor->id]);
@@ -552,7 +552,7 @@ class CoreTest extends TestCase
         /** @var $keypairs \Generator */
         require_once $this->sampleFile([], 'keypairs/list_keypairs.php');
 
-        $this->assertInstanceOf(\Generator::class, $keypairs);
+        self::assertInstanceOf(\Generator::class, $keypairs);
 
         $this->logStep('Listed all keypairs');
     }
@@ -567,9 +567,9 @@ class CoreTest extends TestCase
         require_once $this->sampleFile($replacements, 'keypairs/create_keypair.php');
         /**@var Keypair $keypair */
 
-        $this->assertInstanceOf(Keypair::class, $keypair);
-        $this->assertEquals($replacements['{name}'], $keypair->name);
-        $this->assertEquals($replacements['{publicKey}'], $keypair->publicKey);
+        self::assertInstanceOf(Keypair::class, $keypair);
+        self::assertEquals($replacements['{name}'], $keypair->name);
+        self::assertEquals($replacements['{publicKey}'], $keypair->publicKey);
 
         $this->keypairName = $keypair->name;
         $this->logStep('Created keypair name {name}', ['{name}' => $keypair->name]);
@@ -584,9 +584,9 @@ class CoreTest extends TestCase
         require_once $this->sampleFile($replacements, 'keypairs/get_keypair.php');
 
         /**@var Keypair $keypair */
-        $this->assertInstanceOf(Keypair::class, $keypair);
+        self::assertInstanceOf(Keypair::class, $keypair);
 
-        $this->assertEquals($replacements['{name}'], $keypair->name);
+        self::assertEquals($replacements['{name}'], $keypair->name);
 
         $this->logStep('Retrieved details for keypair {name}', $replacements);
     }
@@ -617,8 +617,8 @@ class CoreTest extends TestCase
         require_once $this->sampleFile($replacements, 'hypervisors/get_hypervisor.php');
 
         /**@var Hypervisor $hypervisor */
-        $this->assertInstanceOf(Hypervisor::class, $hypervisor);
-        $this->assertEquals($replacements['{hypervisorId}'], $hypervisor->id);
+        self::assertInstanceOf(Hypervisor::class, $hypervisor);
+        self::assertEquals($replacements['{hypervisorId}'], $hypervisor->id);
 
         $this->logStep('Retrieved details for hypervisor id {hypervisorId}', $replacements);
     }
@@ -628,7 +628,7 @@ class CoreTest extends TestCase
         require_once  $this->sampleFile([], 'hypervisors/get_hypervisors_statistics.php');
 
         /**@var HypervisorStatistic $hypervisorStatistics */
-        $this->assertInstanceOf(HypervisorStatistic::class, $hypervisorStatistics);
+        self::assertInstanceOf(HypervisorStatistic::class, $hypervisorStatistics);
 
         $this->logStep('Retrieved hypervisors statistics');
     }
@@ -638,7 +638,7 @@ class CoreTest extends TestCase
         require_once $this->sampleFile([], 'limits/get_limits.php');
 
         /**@var Limit $limit */
-        $this->assertInstanceOf(Limit::class, $limit);
+        self::assertInstanceOf(Limit::class, $limit);
 
         $this->logStep('Retrieved tenant limit');
     }
@@ -665,7 +665,7 @@ class CoreTest extends TestCase
         require_once  $this->sampleFile($replacements, 'servers/list_security_groups.php');
 
         /**@var \Generator $securityGroups */
-        $this->assertInstanceOf(\Generator::class, $securityGroups);
+        self::assertInstanceOf(\Generator::class, $securityGroups);
 
         $this->logStep('Listed all security groups attached to server {serverId}', $replacements);
     }

--- a/tests/integration/Identity/v3/CoreTest.php
+++ b/tests/integration/Identity/v3/CoreTest.php
@@ -38,34 +38,34 @@ class CoreTest extends TestCase
         /** @var $token \OpenStack\Identity\v3\Models\Token */
         $path = $this->sampleFile([], 'tokens/generate_token_with_username.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Token::class, $token);
+        self::assertInstanceOf(Models\Token::class, $token);
 
         /** @var $token \OpenStack\Identity\v3\Models\Token */
         $path = $this->sampleFile([], 'tokens/generate_token_with_user_id.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Token::class, $token);
+        self::assertInstanceOf(Models\Token::class, $token);
 
         $replacements = ['{tokenId}' => $token->id];
 
         /** @var $token \OpenStack\Identity\v3\Models\Token */
         $path = $this->sampleFile($replacements, 'tokens/generate_token_scoped_to_project_id.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Token::class, $token);
+        self::assertInstanceOf(Models\Token::class, $token);
 
         /** @var $token \OpenStack\Identity\v3\Models\Token */
         $path = $this->sampleFile($replacements, 'tokens/generate_token_scoped_to_project_name.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Token::class, $token);
+        self::assertInstanceOf(Models\Token::class, $token);
 
         /** @var $token \OpenStack\Identity\v3\Models\Token */
         $path = $this->sampleFile($replacements, 'tokens/generate_token_from_id.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Token::class, $token);
+        self::assertInstanceOf(Models\Token::class, $token);
 
         /** @var $result bool */
         $path = $this->sampleFile($replacements, 'tokens/validate_token.php');
         require_once $path;
-        $this->assertTrue($result);
+        self::assertTrue($result);
 
         $path = $this->sampleFile($replacements, 'tokens/revoke_token.php');
         require_once $path;
@@ -73,7 +73,7 @@ class CoreTest extends TestCase
         /** @var $result bool */
         $path = $this->sampleFile($replacements, 'tokens/validate_token.php');
         require_once $path;
-        $this->assertFalse($result);
+        self::assertFalse($result);
     }
 
     public function domains()
@@ -86,7 +86,7 @@ class CoreTest extends TestCase
         /** @var $domain \OpenStack\Identity\v3\Models\Domain */
         $path = $this->sampleFile($replacements, 'domains/add_domain.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Domain::class, $domain);
+        self::assertInstanceOf(Models\Domain::class, $domain);
 
         $replacements['{domainId}'] = $domain->id;
 
@@ -96,7 +96,7 @@ class CoreTest extends TestCase
         /** @var $domain \OpenStack\Identity\v3\Models\Domain */
         $path = $this->sampleFile($replacements, 'domains/show_domain.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Domain::class, $domain);
+        self::assertInstanceOf(Models\Domain::class, $domain);
 
         $parentRole = $this->getService()->createRole(['name' => $this->randomStr()]);
         $group = $this->getService()->createGroup(['name' => $this->randomStr(), 'domainId' => $domain->id]);
@@ -107,7 +107,7 @@ class CoreTest extends TestCase
         /** @var $result bool */
         $path = $this->sampleFile($replacements + ['{groupId}' => $group->id, '{roleId}' => $parentRole->id], 'domains/check_group_role.php');
         require_once $path;
-        $this->assertTrue($result);
+        self::assertTrue($result);
 
         $path = $this->sampleFile($replacements + ['{groupId}' => $group->id], 'domains/list_group_roles.php');
         require_once $path;
@@ -125,7 +125,7 @@ class CoreTest extends TestCase
         /** @var $result bool */
         $path = $this->sampleFile($replacements + ['{domainUserId}' => $user->id, '{roleId}' => $parentRole->id], 'domains/check_user_role.php');
         require_once $path;
-        $this->assertTrue($result);
+        self::assertTrue($result);
 
         $path = $this->sampleFile($replacements + ['{domainUserId}' => $user->id], 'domains/list_user_roles.php');
         require_once $path;
@@ -139,7 +139,7 @@ class CoreTest extends TestCase
         /** @var $domain \OpenStack\Identity\v3\Models\Domain */
         $path = $this->sampleFile($replacements, 'domains/update_domain.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Domain::class, $domain);
+        self::assertInstanceOf(Models\Domain::class, $domain);
 
         $path = $this->sampleFile($replacements, 'domains/delete_domain.php');
         require_once $path;
@@ -159,7 +159,7 @@ class CoreTest extends TestCase
         /** @var $endpoint \OpenStack\Identity\v3\Models\Endpoint */
         $path = $this->sampleFile($replacements, 'endpoints/add_endpoint.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Endpoint::class, $endpoint);
+        self::assertInstanceOf(Models\Endpoint::class, $endpoint);
 
         $replacements['{endpointId}'] = $endpoint->id;
 
@@ -186,7 +186,7 @@ class CoreTest extends TestCase
         /** @var $service \OpenStack\Identity\v3\Models\Service */
         $path = $this->sampleFile($replacements, 'services/add_service.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Service::class, $service);
+        self::assertInstanceOf(Models\Service::class, $service);
 
         $replacements['{serviceId}'] = $service->id;
 
@@ -196,12 +196,12 @@ class CoreTest extends TestCase
         /** @var $service \OpenStack\Identity\v3\Models\Service */
         $path = $this->sampleFile($replacements, 'services/update_service.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Service::class, $service);
+        self::assertInstanceOf(Models\Service::class, $service);
 
         /** @var $service \OpenStack\Identity\v3\Models\Service */
         $path = $this->sampleFile($replacements, 'services/get_service.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Service::class, $service);
+        self::assertInstanceOf(Models\Service::class, $service);
 
         $path = $this->sampleFile($replacements, 'services/delete_service.php');
         require_once $path;
@@ -214,7 +214,7 @@ class CoreTest extends TestCase
         /** @var $group \OpenStack\Identity\v3\Models\Group */
         $path = $this->sampleFile(['{name}' => $this->randomStr(), '{description}' => $this->randomStr()], 'groups/add_group.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Group::class, $group);
+        self::assertInstanceOf(Models\Group::class, $group);
 
         $replacements = ['{groupId}' => $group->id];
 
@@ -224,12 +224,12 @@ class CoreTest extends TestCase
         /** @var $group \OpenStack\Identity\v3\Models\Group */
         $path = $this->sampleFile($replacements, 'groups/get_group.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Group::class, $group);
+        self::assertInstanceOf(Models\Group::class, $group);
 
         /** @var $result bool */
         $path = $this->sampleFile($replacements + ['{groupUserId}' => $groupUser->id], 'groups/check_user_membership.php');
         require_once $path;
-        $this->assertTrue($result);
+        self::assertTrue($result);
 
         $path = $this->sampleFile($replacements, 'groups/list_users.php');
         require_once $path;
@@ -240,7 +240,7 @@ class CoreTest extends TestCase
         /** @var $result bool */
         $path = $this->sampleFile($replacements + ['{groupUserId}' => $groupUser->id], 'groups/check_user_membership.php');
         require_once $path;
-        $this->assertFalse($result);
+        self::assertFalse($result);
 
         $path = $this->sampleFile($replacements + ['{name}' => $this->randomStr(), '{description}' => $this->randomStr()], 'groups/update_group.php');
         require_once $path;
@@ -259,14 +259,14 @@ class CoreTest extends TestCase
         /** @var $project \OpenStack\Identity\v3\Models\Project */
         $path = $this->sampleFile(['{name}' => $this->randomStr(), '{description}' => $this->randomStr()], 'projects/add_project.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Project::class, $project);
+        self::assertInstanceOf(Models\Project::class, $project);
 
         $replacements = ['{id}' => $project->id];
 
         /** @var $project \OpenStack\Identity\v3\Models\Project */
         $path = $this->sampleFile($replacements, 'projects/get_project.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Project::class, $project);
+        self::assertInstanceOf(Models\Project::class, $project);
 
         $domain = $this->getService()->createDomain(['name' => $this->randomStr()]);
         $parentRole = $this->getService()->createRole(['name' => $this->randomStr()]);
@@ -278,7 +278,7 @@ class CoreTest extends TestCase
         /** @var $result bool */
         $path = $this->sampleFile($replacements + ['{groupId}' => $group->id, '{roleId}' => $parentRole->id], 'projects/check_group_role.php');
         require_once $path;
-        $this->assertTrue($result);
+        self::assertTrue($result);
 
         $path = $this->sampleFile($replacements + ['{groupId}' => $group->id], 'projects/list_group_roles.php');
         require_once $path;
@@ -296,7 +296,7 @@ class CoreTest extends TestCase
         /** @var $result bool */
         $path = $this->sampleFile($replacements + ['{projectUserId}' => $user->id, '{roleId}' => $parentRole->id], 'projects/check_user_role.php');
         require_once $path;
-        $this->assertTrue($result);
+        self::assertTrue($result);
 
         $path = $this->sampleFile($replacements + ['{projectUserId}' => $user->id], 'projects/list_user_roles.php');
         require_once $path;
@@ -323,7 +323,7 @@ class CoreTest extends TestCase
         /** @var $role \OpenStack\Identity\v3\Models\Role */
         $path = $this->sampleFile(['{name}' => $this->randomStr()], 'roles/add_role.php');
         require_once $path;
-        $this->assertInstanceOf(Models\Role::class, $role);
+        self::assertInstanceOf(Models\Role::class, $role);
 
         $path = $this->sampleFile([], 'roles/list_roles.php');
         require_once $path;
@@ -350,14 +350,14 @@ class CoreTest extends TestCase
         /** @var $user \OpenStack\Identity\v3\Models\User */
         $path = $this->sampleFile($replacements, 'users/add_user.php');
         require_once $path;
-        $this->assertInstanceOf(Models\User::class, $user);
+        self::assertInstanceOf(Models\User::class, $user);
 
         $replacements = ['{id}' => $user->id];
 
         /** @var $user \OpenStack\Identity\v3\Models\User */
         $path = $this->sampleFile($replacements, 'users/get_user.php');
         require_once $path;
-        $this->assertInstanceOf(Models\User::class, $user);
+        self::assertInstanceOf(Models\User::class, $user);
 
         $path = $this->sampleFile([], 'users/list_users.php');
         require_once $path;
@@ -371,7 +371,7 @@ class CoreTest extends TestCase
         /** @var $user \OpenStack\Identity\v3\Models\User */
         $path = $this->sampleFile($replacements + ['{name}' => $this->randomStr(), '{description}' => $this->randomStr()], 'users/update_user.php');
         require_once $path;
-        $this->assertInstanceOf(Models\User::class, $user);
+        self::assertInstanceOf(Models\User::class, $user);
 
         $path = $this->sampleFile($replacements, 'users/delete_user.php');
         require_once $path;

--- a/tests/integration/Images/v2/CoreTest.php
+++ b/tests/integration/Images/v2/CoreTest.php
@@ -32,7 +32,7 @@ class CoreTest extends TestCase
         $this->logStep('Creating image');
         /** @var Image $image */
         require_once $this->sampleFile($replacements, 'images/create.php');
-        $this->assertInstanceOf(Image::class, $image);
+        self::assertInstanceOf(Image::class, $image);
 
         $replacements = ['{imageId}' => $image->id];
 
@@ -43,7 +43,7 @@ class CoreTest extends TestCase
         $this->logStep('Getting image');
         /** @var Image $image */
         require_once $this->sampleFile($replacements, 'images/get.php');
-        $this->assertInstanceOf(Image::class, $image);
+        self::assertInstanceOf(Image::class, $image);
 
         $replacements += [
             '{name}'       => 'newName',
@@ -83,13 +83,13 @@ class CoreTest extends TestCase
         $replacements += ['{imageId}' => $image->id];
         /** @var Member $member */
         require_once $this->sampleFile(['{imageId}' => $image->id, ], 'members/add.php');
-        $this->assertInstanceOf(Member::class, $member);
+        self::assertInstanceOf(Member::class, $member);
 
         $replacements += ['status' => Member::STATUS_REJECTED];
         $this->logStep('Updating member status');
         /** @var Member $member */
         require_once $this->sampleFile($replacements, 'members/update_status.php');
-        $this->assertInstanceOf(Member::class, $member);
+        self::assertInstanceOf(Member::class, $member);
 
         $this->logStep('Deleting member');
         /** @var Member $member */

--- a/tests/integration/Networking/v2/CoreTest.php
+++ b/tests/integration/Networking/v2/CoreTest.php
@@ -55,8 +55,8 @@ class CoreTest extends TestCase
         require_once $path;
 
         foreach ($networks as $network) {
-            $this->assertInstanceOf(Network::class, $network);
-            $this->assertNotEmpty($network->id);
+            self::assertInstanceOf(Network::class, $network);
+            self::assertNotEmpty($network->id);
 
             $this->networkId = $network->id;
             $this->logStep('Created network {id}', ['{id}' => $this->networkId]);
@@ -75,8 +75,8 @@ class CoreTest extends TestCase
         $path = $this->sampleFile($replacements, 'networks/create.php');
         require_once $path;
 
-        $this->assertInstanceOf(Network::class, $network);
-        $this->assertNotEmpty($network->id);
+        self::assertInstanceOf(Network::class, $network);
+        self::assertNotEmpty($network->id);
 
         $this->logStep('Created network {id}', ['{id}' => $this->networkId]);
 
@@ -96,8 +96,8 @@ class CoreTest extends TestCase
         $path = $this->sampleFile($replacements, 'networks/update.php');
         require_once $path;
 
-        $this->assertInstanceOf(Network::class, $network);
-        $this->assertEquals($name, $network->name);
+        self::assertInstanceOf(Network::class, $network);
+        self::assertEquals($name, $network->name);
 
         $this->logStep('Updated network ID to use this name: NAME', ['ID' => $networkId, 'NAME' => $name]);
     }
@@ -110,7 +110,7 @@ class CoreTest extends TestCase
         $path = $this->sampleFile($replacements, 'networks/get.php');
         require_once $path;
 
-        $this->assertInstanceOf(Network::class, $network);
+        self::assertInstanceOf(Network::class, $network);
 
         $this->logStep('Retrieved the details of network ID', ['ID' => $networkId]);
     }
@@ -144,8 +144,8 @@ class CoreTest extends TestCase
         require_once $path;
 
         foreach ($subnets as $subnet) {
-            $this->assertInstanceOf(Subnet::class, $subnet);
-            $this->assertNotEmpty($subnet->id);
+            self::assertInstanceOf(Subnet::class, $subnet);
+            self::assertNotEmpty($subnet->id);
 
             $this->logStep('Created subnet {id}', ['{id}' => $subnet->id]);
 
@@ -171,8 +171,8 @@ class CoreTest extends TestCase
         $path = $this->sampleFile($replacements, 'subnets/create.php');
         require_once $path;
 
-        $this->assertInstanceOf(Subnet::class, $subnet);
-        $this->assertNotEmpty($subnet->id);
+        self::assertInstanceOf(Subnet::class, $subnet);
+        self::assertNotEmpty($subnet->id);
 
         $this->logStep('Created subnet {id}', ['{id}' => $subnet->id]);
 
@@ -193,8 +193,8 @@ class CoreTest extends TestCase
         $path = $this->sampleFile($replacements, 'subnets/create_with_gateway_ip.php');
         require_once $path;
 
-        $this->assertInstanceOf(Subnet::class, $subnet);
-        $this->assertNotEmpty($subnet->id);
+        self::assertInstanceOf(Subnet::class, $subnet);
+        self::assertNotEmpty($subnet->id);
 
         $this->subnetId = $subnet->id;
 
@@ -218,8 +218,8 @@ class CoreTest extends TestCase
         $path = $this->sampleFile($replacements, 'subnets/create_with_host_routes.php');
         require_once $path;
 
-        $this->assertInstanceOf(Subnet::class, $subnet);
-        $this->assertNotEmpty($subnet->id);
+        self::assertInstanceOf(Subnet::class, $subnet);
+        self::assertNotEmpty($subnet->id);
 
         $this->logStep('Created subnet {id} with host routes', ['{id}' => $subnet->id]);
 
@@ -240,8 +240,8 @@ class CoreTest extends TestCase
         $path = $this->sampleFile($replacements, 'subnets/update.php');
         require_once $path;
 
-        $this->assertInstanceOf(Subnet::class, $subnet);
-        $this->assertEquals($name, $subnet->name);
+        self::assertInstanceOf(Subnet::class, $subnet);
+        self::assertEquals($name, $subnet->name);
 
         $this->logStep('Updated subnet ID to use this name: NAME', ['ID' => $subnetId, 'NAME' => $name]);
     }
@@ -255,7 +255,7 @@ class CoreTest extends TestCase
         $path = $this->sampleFile($replacements, 'subnets/get.php');
         require_once $path;
 
-        $this->assertInstanceOf(Subnet::class, $subnet);
+        self::assertInstanceOf(Subnet::class, $subnet);
 
         $this->logStep('Retrieved the details of subnet ID', ['ID' => $subnetId]);
     }
@@ -294,7 +294,7 @@ class CoreTest extends TestCase
         $path = $this->sampleFile($replacements, 'ports/create_batch.php');
         require_once $path;
         foreach ($ports as $port) {
-            $this->assertInstanceOf(Port::class, $port);
+            self::assertInstanceOf(Port::class, $port);
             $port->delete();
         }
 
@@ -305,12 +305,12 @@ class CoreTest extends TestCase
         /** @var $port \OpenStack\Networking\v2\Models\Port */
         $path = $this->sampleFile($replacements, 'ports/get.php');
         require_once $path;
-        $this->assertInstanceOf(Port::class, $port);
+        self::assertInstanceOf(Port::class, $port);
 
         /** @var $port \OpenStack\Networking\v2\Models\Port */
         $path = $this->sampleFile($replacements, 'ports/update.php');
         require_once $path;
-        $this->assertInstanceOf(Port::class, $port);
+        self::assertInstanceOf(Port::class, $port);
 
         $path = $this->sampleFile($replacements, 'ports/delete.php');
         require_once $path;

--- a/tests/integration/Networking/v2/Layer3Test.php
+++ b/tests/integration/Networking/v2/Layer3Test.php
@@ -118,9 +118,9 @@ class Layer3Test extends TestCase
         /** @var FloatingIp $ip */
         $path = $this->sampleFile($replacements, 'floatingIPs/create.php');
         require_once $path;
-        $this->assertInstanceOf(FloatingIp::class, $ip);
-        $this->assertEquals($externalNetwork->id, $ip->floatingNetworkId);
-        $this->assertEquals($port1->id, $ip->portId);
+        self::assertInstanceOf(FloatingIp::class, $ip);
+        self::assertEquals($externalNetwork->id, $ip->floatingNetworkId);
+        self::assertEquals($port1->id, $ip->portId);
 
         $this->logStep('List floating IPs');
         $path = $this->sampleFile($replacements, 'floatingIPs/list.php');
@@ -130,7 +130,7 @@ class Layer3Test extends TestCase
         $replacements['{id}'] = $ip->id;
         $path = $this->sampleFile($replacements, 'floatingIPs/get.php');
         require_once $path;
-        $this->assertInstanceOf(FloatingIp::class, $ip);
+        self::assertInstanceOf(FloatingIp::class, $ip);
 
         $this->logStep('Update floating IP');
         $port2 = $this->createPort($internalNetwork);

--- a/tests/integration/ObjectStore/v1/CoreTest.php
+++ b/tests/integration/ObjectStore/v1/CoreTest.php
@@ -51,7 +51,7 @@ class CoreTest extends TestCase
         $this->logStep('Getting account metadata');
         /** @var array $metadata */
         require_once $this->sampleFile($replacements, 'account/get_metadata.php');
-        $this->assertArraySubset([
+        self::assertArraySubset([
             'Foo' => $replacements['{val_1}'],
             'Bar' => $replacements['{val_2}'],
         ], $metadata);
@@ -68,7 +68,7 @@ class CoreTest extends TestCase
         $this->logStep('Checking account metadata was reset properly');
         /** @var array $metadata */
         require_once $this->sampleFile($replacements, 'account/get_metadata.php');
-        $this->assertEquals([
+        self::assertEquals([
             'Foo1' => $replacements['{val_1}'],
             'Bar1' => $replacements['{val_2}'],
         ], $metadata);
@@ -100,7 +100,7 @@ class CoreTest extends TestCase
         $this->logStep('Getting metadata');
         /** @var array $metadata */
         require_once $this->sampleFile($replacements, 'containers/get_metadata.php');
-        $this->assertEquals([
+        self::assertEquals([
             'Foo' => $replacements['{val_1}'],
             'Bar' => $replacements['{val_2}'],
         ], $metadata);
@@ -113,7 +113,7 @@ class CoreTest extends TestCase
         require_once $this->sampleFile($replacements, 'containers/reset_metadata.php');
         /** @var array $metadata */
         require_once $this->sampleFile($replacements, 'containers/get_metadata.php');
-        $this->assertEquals([
+        self::assertEquals([
             'Foo1' => $replacements['{val_1}'],
             'Bar1' => $replacements['{val_2}'],
         ], $metadata);
@@ -145,24 +145,24 @@ class CoreTest extends TestCase
         $this->logStep('Check that new object exists');
         /** @var bool $exists */
         require_once $this->sampleFile(['{containerName}' => $containerName, '{objectName}' => $newName], 'objects/check_exists.php');
-        $this->assertTrue($exists);
+        self::assertTrue($exists);
 
         $this->logStep('Downloading object');
         /** @var StreamInterface $stream */
         require_once $this->sampleFile($replacements, 'objects/download.php');
-        $this->assertInstanceOf(StreamInterface::class, $stream);
-        $this->assertEquals(1000, $stream->getSize());
+        self::assertInstanceOf(StreamInterface::class, $stream);
+        self::assertEquals(1000, $stream->getSize());
 
         $this->logStep('Downloading object using streaming');
         /** @var StreamInterface $stream */
         require_once $this->sampleFile($replacements, 'objects/download_stream.php');
-        $this->assertInstanceOf(StreamInterface::class, $stream);
+        self::assertInstanceOf(StreamInterface::class, $stream);
 
         $body = '';
         while (!$stream->eof()) {
             $body .= $stream->read(64);
         }
-        $this->assertEquals(1000, strlen($body));
+        self::assertEquals(1000, strlen($body));
 
         $this->logStep('Get object');
         require_once $this->sampleFile($replacements, 'objects/get.php');
@@ -182,7 +182,7 @@ class CoreTest extends TestCase
         $this->logStep('Getting metadata');
         /** @var array $metadata */
         require_once $this->sampleFile($replacements, 'objects/get_metadata.php');
-        $this->assertEquals([
+        self::assertEquals([
             'Foo' => $replacements['{val_1}'],
             'Bar' => $replacements['{val_2}'],
         ], $metadata);
@@ -195,7 +195,7 @@ class CoreTest extends TestCase
         require_once $this->sampleFile($replacements, 'objects/reset_metadata.php');
         /** @var array $metadata */
         require_once $this->sampleFile($replacements, 'objects/get_metadata.php');
-        $this->assertEquals([
+        self::assertEquals([
             'Foo1' => $replacements['{val_1}'],
             'Bar1' => $replacements['{val_2}'],
         ], $metadata);

--- a/tests/unit/BlockStorage/v2/Models/QuotaSetTest.php
+++ b/tests/unit/BlockStorage/v2/Models/QuotaSetTest.php
@@ -12,7 +12,7 @@ class QuotaSetTest extends TestCase
     /** @var QuotaSet */
     private $quotaSet;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/BlockStorage/v2/Models/QuotaSetTest.php
+++ b/tests/unit/BlockStorage/v2/Models/QuotaSetTest.php
@@ -27,9 +27,9 @@ class QuotaSetTest extends TestCase
         $this->setupMock('GET', 'os-quota-sets/tenant-foo', [], [], 'GET_quota_set');
 
         $this->quotaSet->retrieve();
-        $this->assertEquals(1, $this->quotaSet->gigabytes);
-        $this->assertEquals(2, $this->quotaSet->snapshots);
-        $this->assertEquals(3, $this->quotaSet->volumes);
+        self::assertEquals(1, $this->quotaSet->gigabytes);
+        self::assertEquals(2, $this->quotaSet->snapshots);
+        self::assertEquals(3, $this->quotaSet->volumes);
     }
 
     public function test_it_updates()

--- a/tests/unit/BlockStorage/v2/Models/SnapshotTest.php
+++ b/tests/unit/BlockStorage/v2/Models/SnapshotTest.php
@@ -12,7 +12,7 @@ class SnapshotTest extends TestCase
     /** @var Snapshot */
     private $snapshot;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/BlockStorage/v2/Models/SnapshotTest.php
+++ b/tests/unit/BlockStorage/v2/Models/SnapshotTest.php
@@ -49,7 +49,7 @@ class SnapshotTest extends TestCase
             'bar' => '2',
         ];
 
-        $this->assertEquals($expected, $this->snapshot->getMetadata());
+        self::assertEquals($expected, $this->snapshot->getMetadata());
     }
 
     public function test_it_retrieves()

--- a/tests/unit/BlockStorage/v2/Models/VolumeTest.php
+++ b/tests/unit/BlockStorage/v2/Models/VolumeTest.php
@@ -49,20 +49,20 @@ class VolumeTest extends TestCase
         $volumeImageMetadata = $this->volume->volumeImageMetadata;
 
         self::assertIsArray($volumeImageMetadata);
-        $this->assertEquals($volumeImageMetadata['os_distro'], 'ubuntu');
-        $this->assertEquals($volumeImageMetadata['os_version'], 'xenial');
-        $this->assertEquals($volumeImageMetadata['hypervisor_type'], 'qemu');
-        $this->assertEquals($volumeImageMetadata['os_variant'], 'ubuntu');
-        $this->assertEquals($volumeImageMetadata['disk_format'], 'qcow2');
-        $this->assertEquals($volumeImageMetadata['image_name'], 'Some Image Name x86_64');
-        $this->assertEquals($volumeImageMetadata['image_id'], '54986297-8364-4baa-8435-812add437507');
-        $this->assertEquals($volumeImageMetadata['architecture'], 'x86_64');
-        $this->assertEquals($volumeImageMetadata['container_format'], 'bare');
-        $this->assertEquals($volumeImageMetadata['min_disk'], '40');
-        $this->assertEquals($volumeImageMetadata['os_type'], 'linux');
-        $this->assertEquals($volumeImageMetadata['checksum'], 'bb3055b274fe72bc3406ffe9febe9fff');
-        $this->assertEquals($volumeImageMetadata['min_ram'], '0');
-        $this->assertEquals($volumeImageMetadata['size'], '6508557824');
+        self::assertEquals($volumeImageMetadata['os_distro'], 'ubuntu');
+        self::assertEquals($volumeImageMetadata['os_version'], 'xenial');
+        self::assertEquals($volumeImageMetadata['hypervisor_type'], 'qemu');
+        self::assertEquals($volumeImageMetadata['os_variant'], 'ubuntu');
+        self::assertEquals($volumeImageMetadata['disk_format'], 'qcow2');
+        self::assertEquals($volumeImageMetadata['image_name'], 'Some Image Name x86_64');
+        self::assertEquals($volumeImageMetadata['image_id'], '54986297-8364-4baa-8435-812add437507');
+        self::assertEquals($volumeImageMetadata['architecture'], 'x86_64');
+        self::assertEquals($volumeImageMetadata['container_format'], 'bare');
+        self::assertEquals($volumeImageMetadata['min_disk'], '40');
+        self::assertEquals($volumeImageMetadata['os_type'], 'linux');
+        self::assertEquals($volumeImageMetadata['checksum'], 'bb3055b274fe72bc3406ffe9febe9fff');
+        self::assertEquals($volumeImageMetadata['min_ram'], '0');
+        self::assertEquals($volumeImageMetadata['size'], '6508557824');
     }
 
     public function test_it_merges_metadata()

--- a/tests/unit/BlockStorage/v2/Models/VolumeTest.php
+++ b/tests/unit/BlockStorage/v2/Models/VolumeTest.php
@@ -12,7 +12,7 @@ class VolumeTest extends TestCase
     /** @var Volume */
     private $volume;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -48,7 +48,7 @@ class VolumeTest extends TestCase
 
         $volumeImageMetadata = $this->volume->volumeImageMetadata;
 
-        $this->assertInternalType('array', $volumeImageMetadata);
+        self::assertIsArray($volumeImageMetadata);
         $this->assertEquals($volumeImageMetadata['os_distro'], 'ubuntu');
         $this->assertEquals($volumeImageMetadata['os_version'], 'xenial');
         $this->assertEquals($volumeImageMetadata['hypervisor_type'], 'qemu');

--- a/tests/unit/BlockStorage/v2/Models/VolumeTypeTest.php
+++ b/tests/unit/BlockStorage/v2/Models/VolumeTypeTest.php
@@ -12,7 +12,7 @@ class VolumeTypeTest extends TestCase
     /** @var VolumeType */
     private $volumeType;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/BlockStorage/v2/ServiceTest.php
+++ b/tests/unit/BlockStorage/v2/ServiceTest.php
@@ -16,7 +16,7 @@ class ServiceTest extends TestCase
     /** @var Service */
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/BlockStorage/v2/ServiceTest.php
+++ b/tests/unit/BlockStorage/v2/ServiceTest.php
@@ -61,7 +61,7 @@ class ServiceTest extends TestCase
 
         $this->setupMock('POST', 'volumes', $expectedJson, [], 'GET_volume');
 
-        $this->assertInstanceOf(Volume::class, $this->service->createVolume($opts));
+        self::assertInstanceOf(Volume::class, $this->service->createVolume($opts));
     }
 
     public function test_it_lists_volumes()
@@ -80,18 +80,18 @@ class ServiceTest extends TestCase
 
         foreach ($this->service->listVolumes(false) as $volume) {
             $count++;
-            $this->assertInstanceOf(Volume::class, $volume);
+            self::assertInstanceOf(Volume::class, $volume);
         }
 
-        $this->assertEquals(2, $count);
+        self::assertEquals(2, $count);
     }
 
     public function test_it_gets_a_volume()
     {
         $volume = $this->service->getVolume('volumeId');
 
-        $this->assertInstanceOf(Volume::class, $volume);
-        $this->assertEquals('volumeId', $volume->id);
+        self::assertInstanceOf(Volume::class, $volume);
+        self::assertEquals('volumeId', $volume->id);
     }
 
     public function test_it_creates_volume_types()
@@ -102,7 +102,7 @@ class ServiceTest extends TestCase
 
         $this->setupMock('POST', 'types', $expectedJson, [], 'GET_type');
 
-        $this->assertInstanceOf(VolumeType::class, $this->service->createVolumeType($opts));
+        self::assertInstanceOf(VolumeType::class, $this->service->createVolumeType($opts));
     }
 
     public function test_it_lists_volume_types()
@@ -116,18 +116,18 @@ class ServiceTest extends TestCase
 
         foreach ($this->service->listVolumeTypes() as $type) {
             $count++;
-            $this->assertInstanceOf(VolumeType::class, $type);
+            self::assertInstanceOf(VolumeType::class, $type);
         }
 
-        $this->assertEquals(2, $count);
+        self::assertEquals(2, $count);
     }
 
     public function test_it_gets_a_volume_type()
     {
         $type = $this->service->getVolumeType('id');
 
-        $this->assertInstanceOf(VolumeType::class, $type);
-        $this->assertEquals('id', $type->id);
+        self::assertInstanceOf(VolumeType::class, $type);
+        self::assertEquals('id', $type->id);
     }
 
     public function test_it_creates_snapshots()
@@ -148,7 +148,7 @@ class ServiceTest extends TestCase
 
         $this->setupMock('POST', 'snapshots', $expectedJson, [], 'GET_snapshot');
 
-        $this->assertInstanceOf(Snapshot::class, $this->service->createSnapshot($opts));
+        self::assertInstanceOf(Snapshot::class, $this->service->createSnapshot($opts));
     }
 
     public function test_it_lists_snapshots()
@@ -167,18 +167,18 @@ class ServiceTest extends TestCase
 
         foreach ($this->service->listSnapshots(false) as $snapshot) {
             $count++;
-            $this->assertInstanceOf(Snapshot::class, $snapshot);
+            self::assertInstanceOf(Snapshot::class, $snapshot);
         }
 
-        $this->assertEquals(2, $count);
+        self::assertEquals(2, $count);
     }
 
     public function test_it_gets_a_snapshot()
     {
         $snapshot = $this->service->getSnapshot('snapshotId');
 
-        $this->assertInstanceOf(Snapshot::class, $snapshot);
-        $this->assertEquals('snapshotId', $snapshot->id);
+        self::assertInstanceOf(Snapshot::class, $snapshot);
+        self::assertEquals('snapshotId', $snapshot->id);
     }
 
     public function test_it_gets_quota_set()
@@ -190,9 +190,9 @@ class ServiceTest extends TestCase
 
         $quotaSet = $this->service->getQuotaSet('tenant-id-1234');
 
-        $this->assertInstanceOf(QuotaSet::class, $quotaSet);
-        $this->assertEquals(1, $quotaSet->gigabytes);
-        $this->assertEquals(2, $quotaSet->snapshots);
-        $this->assertEquals(3, $quotaSet->volumes);
+        self::assertInstanceOf(QuotaSet::class, $quotaSet);
+        self::assertEquals(1, $quotaSet->gigabytes);
+        self::assertEquals(2, $quotaSet->snapshots);
+        self::assertEquals(3, $quotaSet->volumes);
     }
 }

--- a/tests/unit/Common/Api/OperationTest.php
+++ b/tests/unit/Common/Api/OperationTest.php
@@ -19,18 +19,18 @@ class OperationTest extends \PHPUnit\Framework\TestCase
 
     public function test_it_reveals_whether_params_are_set_or_not()
     {
-        $this->assertFalse($this->operation->hasParam('foo'));
-        $this->assertTrue($this->operation->hasParam('name'));
+        self::assertFalse($this->operation->hasParam('foo'));
+        self::assertTrue($this->operation->hasParam('name'));
     }
 
     public function test_it_gets_params()
     {
-        $this->assertInstanceOf(Parameter::class, $this->operation->getParam('name'));
+        self::assertInstanceOf(Parameter::class, $this->operation->getParam('name'));
     }
 
     public function test_it_validates_params()
     {
-        $this->assertTrue($this->operation->validate([
+        self::assertTrue($this->operation->validate([
             'name'     => 'foo',
             'imageId'  => 'bar',
             'flavorId' => 'baz',
@@ -40,7 +40,7 @@ class OperationTest extends \PHPUnit\Framework\TestCase
     public function test_exceptions_are_propagated()
     {
 		$this->expectException(\Exception::class);
-        $this->assertFalse($this->operation->validate([
+        self::assertFalse($this->operation->validate([
             'name'     => true,
             'imageId'  => 'bar',
             'flavorId' => 'baz',
@@ -63,6 +63,6 @@ class OperationTest extends \PHPUnit\Framework\TestCase
 
     public function test_it_gets_json_key()
     {
-        $this->assertEquals('server', $this->operation->getJsonKey());
+        self::assertEquals('server', $this->operation->getJsonKey());
     }
 }

--- a/tests/unit/Common/Api/OperationTest.php
+++ b/tests/unit/Common/Api/OperationTest.php
@@ -10,7 +10,7 @@ class OperationTest extends \PHPUnit\Framework\TestCase
 {
     private $operation;
 
-    public function setUp()
+    public function setUp(): void
     {
         $def = (new ComputeV2Api())->postServer();
 
@@ -37,11 +37,9 @@ class OperationTest extends \PHPUnit\Framework\TestCase
         ]));
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_exceptions_are_propagated()
     {
+		$this->expectException(\Exception::class);
         $this->assertFalse($this->operation->validate([
             'name'     => true,
             'imageId'  => 'bar',
@@ -49,20 +47,16 @@ class OperationTest extends \PHPUnit\Framework\TestCase
         ]));
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_an_exception_is_thrown_when_user_does_not_provide_required_options()
     {
+		$this->expectException(\Exception::class);
         $this->operation->validate([]);
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_it_throws_exception_when_user_provides_undefined_options()
     {
         $userData = ['name' => 'new_server', 'undefined_opt' => 'bah'];
+		$this->expectException(\Exception::class);
 
         $this->operation->validate($userData);
     }

--- a/tests/unit/Common/Api/OperatorTraitTest.php
+++ b/tests/unit/Common/Api/OperatorTraitTest.php
@@ -20,7 +20,7 @@ class OperatorTraitTest extends TestCase
 
     private $def;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -74,19 +74,15 @@ class OperatorTraitTest extends TestCase
         $promise->wait();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function test_it_throws_exception_when_async_is_called_on_a_non_existent_method()
     {
+		$this->expectException(\RuntimeException::class);
         $this->operator->fooAsync();
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_undefined_methods_result_in_error()
     {
+		$this->expectException(\Exception::class);
         $this->operator->foo();
     }
 

--- a/tests/unit/Common/Api/OperatorTraitTest.php
+++ b/tests/unit/Common/Api/OperatorTraitTest.php
@@ -37,7 +37,7 @@ class OperatorTraitTest extends TestCase
 
     public function test_it_returns_operations()
     {
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             Operation::class,
             $this->operator->getOperation($this->def, [])
         );
@@ -65,10 +65,10 @@ class OperatorTraitTest extends TestCase
     {
         $promise = $this->operator->createAsync('something');
 
-        $this->assertInstanceOf(Promise::class, $promise);
+        self::assertInstanceOf(Promise::class, $promise);
 
         $promise->then(function ($val) {
-            $this->assertEquals('Created something', $val);
+            self::assertEquals('Created something', $val);
         });
 
         $promise->wait();
@@ -88,18 +88,18 @@ class OperatorTraitTest extends TestCase
 
     public function test_it_returns_a_model_instance()
     {
-        $this->assertInstanceOf(ResourceInterface::class, $this->operator->model(TestResource::class));
+        self::assertInstanceOf(ResourceInterface::class, $this->operator->model(TestResource::class));
     }
 
     public function test_it_populates_models_from_response()
     {
-        $this->assertInstanceOf(ResourceInterface::class, $this->operator->model(TestResource::class, new Response(200)));
+        self::assertInstanceOf(ResourceInterface::class, $this->operator->model(TestResource::class, new Response(200)));
     }
 
     public function test_it_populates_models_from_arrays()
     {
         $data = ['flavor' => [], 'image' => []];
-        $this->assertInstanceOf(ResourceInterface::class, $this->operator->model(TestResource::class, $data));
+        self::assertInstanceOf(ResourceInterface::class, $this->operator->model(TestResource::class, $data));
     }
 
     public function test_guzzle_options_are_forwarded()

--- a/tests/unit/Common/Api/ParameterTest.php
+++ b/tests/unit/Common/Api/ParameterTest.php
@@ -11,7 +11,7 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
     private $data;
     private $api;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->api = new ComputeV2Api();
 
@@ -19,13 +19,11 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
         $this->param = new Parameter($this->data);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function test_exception_is_thrown_for_invalid_locations()
     {
         $data = $this->data;
         $data['location'] = 'foo';
+		$this->expectException(\RuntimeException::class);
         new Parameter($data);
     }
 
@@ -82,25 +80,21 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->param->validate('TestName'));
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_it_throws_exception_when_values_do_not_match_their_definition_types()
     {
         $data = $this->api->postServer()['params']['networks'] + ['name' => 'networks'];
         $param = new Parameter($data);
+		$this->expectException(\Exception::class);
 
         $param->validate('a_network!'); // should be an array
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_it_throws_exception_when_deeply_nested_values_have_wrong_types()
     {
         $data = $this->api->postServer()['params']['networks'] + ['name' => 'networks'];
-
         $param = new Parameter($data);
+		$this->expectException(\Exception::class);
+
         $param->validate(['name' => false]); // value should be a string, not bool
     }
 
@@ -134,15 +128,13 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($param->validate($userVals));
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_an_exception_is_thrown_when_an_undefined_property_is_provided()
     {
         $params = ['type' => 'object', 'properties' => ['foo' => ['type' => 'string']]];
         $userVals = ['bar' => 'baz'];
-
         $param = new Parameter($params);
+		$this->expectException(\Exception::class);
+
         $param->validate($userVals);
     }
 
@@ -187,15 +179,13 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('foo-metadata', $property->getPrefixedName());
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_exception_is_thrown_when_value_is_not_in_enum_list()
     {
         $data = $this->data;
         $data['enum'] = ['foo'];
-
         $param = new Parameter($data);
+		$this->expectException(\Exception::class);
+
         $param->validate('blah');
     }
 }

--- a/tests/unit/Common/Api/ParameterTest.php
+++ b/tests/unit/Common/Api/ParameterTest.php
@@ -29,7 +29,7 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
 
     public function test_it_should_provide_access_to_a_name()
     {
-        $this->assertEquals($this->data['name'], $this->param->getName());
+        self::assertEquals($this->data['name'], $this->param->getName());
     }
 
     public function test_it_should_use_sentAs_alias_for_name_if_one_is_set()
@@ -37,12 +37,12 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
         $data = $this->data + ['sentAs' => 'foo'];
         $param = new Parameter($data);
 
-        $this->assertEquals($data['sentAs'], $param->getName());
+        self::assertEquals($data['sentAs'], $param->getName());
     }
 
     public function test_it_indicates_whether_it_is_required_or_not()
     {
-        $this->assertTrue($this->param->isRequired());
+        self::assertTrue($this->param->isRequired());
     }
 
     public function test_it_indicates_its_item_schema()
@@ -50,7 +50,7 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
         $data = $this->api->postServer()['params']['networks'] + ['name' => 'networks'];
         $param = new Parameter($data);
 
-        $this->assertInstanceOf(Parameter::class, $param->getItemSchema());
+        self::assertInstanceOf(Parameter::class, $param->getItemSchema());
     }
 
     public function test_it_allows_property_retrieval()
@@ -58,7 +58,7 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
         $definition = $this->api->postServer()['params']['networks']['items'] + ['name' => 'network'];
         $param = new Parameter($definition);
 
-        $this->assertInstanceOf(Parameter::class, $param->getProperty('uuid'));
+        self::assertInstanceOf(Parameter::class, $param->getProperty('uuid'));
     }
 
     public function test_it_indicates_its_path()
@@ -66,18 +66,18 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
         $path = 'foo.bar.baz';
         $param = new Parameter($this->data + ['path' => $path]);
 
-        $this->assertEquals($path, $param->getPath());
+        self::assertEquals($path, $param->getPath());
     }
 
     public function test_it_verifies_a_given_location_with_a_boolean()
     {
-        $this->assertFalse($this->param->hasLocation('foo'));
-        $this->assertTrue($this->param->hasLocation('json'));
+        self::assertFalse($this->param->hasLocation('foo'));
+        self::assertTrue($this->param->hasLocation('json'));
     }
 
     public function test_it_should_return_true_when_required_attributes_are_provided_and_match_their_definitions()
     {
-        $this->assertTrue($this->param->validate('TestName'));
+        self::assertTrue($this->param->validate('TestName'));
     }
 
     public function test_it_throws_exception_when_values_do_not_match_their_definition_types()
@@ -111,7 +111,7 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
         $userValues = ['some' => 'value'];
 
         $param = new Parameter($params);
-        $this->assertTrue($param->validate($userValues));
+        self::assertTrue($param->validate($userValues));
     }
 
     public function test_it_passes_validation_when_array_values_pass()
@@ -125,7 +125,7 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
         $userVals = ['1', '2', '3'];
 
         $param = new Parameter($params);
-        $this->assertTrue($param->validate($userVals));
+        self::assertTrue($param->validate($userVals));
     }
 
     public function test_an_exception_is_thrown_when_an_undefined_property_is_provided()
@@ -144,13 +144,13 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
         $userVals = ['foo' => 'baz'];
 
         $param = new Parameter($params);
-        $this->assertTrue($param->validate($userVals));
+        self::assertTrue($param->validate($userVals));
     }
 
     public function test_it_sets_name()
     {
         $this->param->setName('foo');
-        $this->assertEquals($this->param->getName(), 'foo');
+        self::assertEquals($this->param->getName(), 'foo');
     }
 
     public function test_it_gets_property()
@@ -165,8 +165,8 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
 
         $prop = $property->getProperty('metadata');
 
-        $this->assertInstanceOf(Parameter::class, $prop);
-        $this->assertEquals('foo', $prop->getPrefix());
+        self::assertInstanceOf(Parameter::class, $prop);
+        self::assertEquals('foo', $prop->getPrefix());
     }
 
     public function test_it_gets_prefixed_name()
@@ -176,7 +176,7 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
             'prefix' => 'foo-',
         ]);
 
-        $this->assertEquals('foo-metadata', $property->getPrefixedName());
+        self::assertEquals('foo-metadata', $property->getPrefixedName());
     }
 
     public function test_exception_is_thrown_when_value_is_not_in_enum_list()

--- a/tests/unit/Common/ArrayAccessTraitTest.php
+++ b/tests/unit/Common/ArrayAccessTraitTest.php
@@ -9,7 +9,7 @@ class ArrayAccessTraitTest extends TestCase
 {
     private $aa;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->aa = new ArrayAccess();
     }

--- a/tests/unit/Common/ArrayAccessTraitTest.php
+++ b/tests/unit/Common/ArrayAccessTraitTest.php
@@ -17,34 +17,34 @@ class ArrayAccessTraitTest extends TestCase
     public function test_offset_is_set()
     {
         $this->aa->offsetSet('foo', 'bar');
-        $this->assertEquals(['foo' => 'bar'], $this->aa->getElements());
+        self::assertEquals(['foo' => 'bar'], $this->aa->getElements());
     }
 
     public function test_it_appends_if_no_key_is_set()
     {
         $this->aa->offsetSet(null, 'bar');
-        $this->assertEquals(['bar'], $this->aa->getElements());
+        self::assertEquals(['bar'], $this->aa->getElements());
     }
 
     public function test_if_checks_if_offset_exists()
     {
         $this->aa->offsetSet('bar', 'foo');
-        $this->assertTrue($this->aa->offsetExists('bar'));
-        $this->assertFalse($this->aa->offsetExists('baz'));
+        self::assertTrue($this->aa->offsetExists('bar'));
+        self::assertFalse($this->aa->offsetExists('baz'));
     }
 
     public function test_if_gets_offset()
     {
         $this->aa->offsetSet('bar', 'foo');
-        $this->assertEquals('foo', $this->aa->offsetGet('bar'));
-        $this->assertNull($this->aa->offsetGet('baz'));
+        self::assertEquals('foo', $this->aa->offsetGet('bar'));
+        self::assertNull($this->aa->offsetGet('baz'));
     }
 
     public function test_it_unsets_offset()
     {
         $this->aa->offsetSet('bar', 'foo');
         $this->aa->offsetUnset('bar');
-        $this->assertNull($this->aa->offsetGet('bar'));
+        self::assertNull($this->aa->offsetGet('bar'));
     }
 }
 

--- a/tests/unit/Common/Auth/AuthHandlerTest.php
+++ b/tests/unit/Common/Auth/AuthHandlerTest.php
@@ -35,7 +35,7 @@ class AuthHandlerTest extends TestCase
         // Fake a Keystone request
         $request = new Request('POST', 'https://my-openstack.org:5000/v2.0/tokens');
 
-        $this->assertEquals($request, call_user_func_array($this->handler, [$request, []]));
+        self::assertEquals($request, call_user_func_array($this->handler, [$request, []]));
     }
 
     public function test_it_should_generate_a_new_token_if_the_current_token_is_either_expired_or_not_set()

--- a/tests/unit/Common/Auth/AuthHandlerTest.php
+++ b/tests/unit/Common/Auth/AuthHandlerTest.php
@@ -15,7 +15,7 @@ class AuthHandlerTest extends TestCase
     private $generator;
     private $handler;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->generator = function () {
             $token = $this->prophesize(FakeToken::class);

--- a/tests/unit/Common/Error/BadResponseErrorTest.php
+++ b/tests/unit/Common/Error/BadResponseErrorTest.php
@@ -21,7 +21,7 @@ class BadResponseErrorTest extends TestCase
         $r = new Request('GET', '');
 
         $this->e->setRequest($r);
-        $this->assertEquals($this->e->getRequest(), $r);
+        self::assertEquals($this->e->getRequest(), $r);
     }
 
     public function test_it_gets_response()
@@ -29,6 +29,6 @@ class BadResponseErrorTest extends TestCase
         $r = new Response(500);
 
         $this->e->setResponse($r);
-        $this->assertEquals($this->e->getResponse(), $r);
+        self::assertEquals($this->e->getResponse(), $r);
     }
 }

--- a/tests/unit/Common/Error/BadResponseErrorTest.php
+++ b/tests/unit/Common/Error/BadResponseErrorTest.php
@@ -11,7 +11,7 @@ class BadResponseErrorTest extends TestCase
 {
     private $e;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->e = new BadResponseError();
     }

--- a/tests/unit/Common/Error/BuilderTest.php
+++ b/tests/unit/Common/Error/BuilderTest.php
@@ -18,7 +18,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
     private $builder;
     private $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = $this->prophesize(ClientInterface::class);
         $this->builder = new Builder($this->client->reveal());

--- a/tests/unit/Common/Error/BuilderTest.php
+++ b/tests/unit/Common/Error/BuilderTest.php
@@ -26,7 +26,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
 
     public function test_it_injects_client()
     {
-        $this->assertInstanceOf(Builder::class, new Builder($this->client->reveal()));
+        self::assertInstanceOf(Builder::class, new Builder($this->client->reveal()));
     }
 
     public function test_it_builds_http_errors()
@@ -59,7 +59,7 @@ EOT;
         $e->setRequest($request);
         $e->setResponse($response);
 
-        $this->assertEquals($e, $this->builder->httpError($request, $response));
+        self::assertEquals($e, $this->builder->httpError($request, $response));
     }
 
     public function test_it_builds_user_input_errors()
@@ -88,7 +88,7 @@ EOT;
 
         $e = new UserInputError($errorMessage);
 
-        $this->assertEquals($e, $this->builder->userInputError($expected, $value, 'index.html'));
+        self::assertEquals($e, $this->builder->userInputError($expected, $value, 'index.html'));
     }
 
     public function test_dead_links_are_ignored()
@@ -116,6 +116,6 @@ EOT;
 
         $e = new UserInputError($errorMessage);
 
-        $this->assertEquals($e, $this->builder->userInputError($expected, $value, 'sdffsda'));
+        self::assertEquals($e, $this->builder->userInputError($expected, $value, 'sdffsda'));
     }
 }

--- a/tests/unit/Common/HydratorStrategyTraitTest.php
+++ b/tests/unit/Common/HydratorStrategyTraitTest.php
@@ -21,16 +21,16 @@ class HydratorStrategyTraitTest extends TestCase
 
         $this->fixture->hydrate($data);
 
-        $this->assertEquals(1, $this->fixture->foo);
-        $this->assertEquals(2, $this->fixture->getBar());
-        $this->assertEquals(3, $this->fixture->getBaz());
+        self::assertEquals(1, $this->fixture->foo);
+        self::assertEquals(2, $this->fixture->getBar());
+        self::assertEquals(3, $this->fixture->getBaz());
     }
 
     public function test_it_hydrates_aliases()
     {
         $this->fixture->hydrate(['FOO!' => 1], ['FOO!' => 'foo']);
 
-        $this->assertEquals(1, $this->fixture->foo);
+        self::assertEquals(1, $this->fixture->foo);
     }
 
     public function test_it_sets()
@@ -38,7 +38,7 @@ class HydratorStrategyTraitTest extends TestCase
         $data = ['foo1' => 1];
 
         $this->fixture->set('foo1', 'foo', $data);
-        $this->assertEquals(1, $this->fixture->foo);
+        self::assertEquals(1, $this->fixture->foo);
     }
 }
 

--- a/tests/unit/Common/HydratorStrategyTraitTest.php
+++ b/tests/unit/Common/HydratorStrategyTraitTest.php
@@ -10,7 +10,7 @@ class HydratorStrategyTraitTest extends TestCase
     /** @var Fixture */
     private $fixture;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fixture = new Fixture();
     }

--- a/tests/unit/Common/JsonPathTest.php
+++ b/tests/unit/Common/JsonPathTest.php
@@ -25,7 +25,7 @@ class JsonPathTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $this->assertEquals($expected, $this->jsonPath->getStructure());
+        self::assertEquals($expected, $this->jsonPath->getStructure());
     }
 
     public function test_it_sets_arrays_according_to_paths()
@@ -49,7 +49,7 @@ class JsonPathTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $this->assertEquals($expected, $jsonPath->getStructure());
+        self::assertEquals($expected, $jsonPath->getStructure());
     }
 
     public function test_it_gets_values_according_to_paths()
@@ -63,8 +63,8 @@ class JsonPathTest extends \PHPUnit\Framework\TestCase
             ]
         ]);
 
-        $this->assertEquals('VALUE_1', $jsonPath->get('foo.bar.baz'));
-        $this->assertEquals('VALUE_2', $jsonPath->get('foo.bar.lol'));
-        $this->assertNull($jsonPath->get('foo.bar.boo'));
+        self::assertEquals('VALUE_1', $jsonPath->get('foo.bar.baz'));
+        self::assertEquals('VALUE_2', $jsonPath->get('foo.bar.lol'));
+        self::assertNull($jsonPath->get('foo.bar.boo'));
     }
 }

--- a/tests/unit/Common/JsonPathTest.php
+++ b/tests/unit/Common/JsonPathTest.php
@@ -8,7 +8,7 @@ class JsonPathTest extends \PHPUnit\Framework\TestCase
 {
     private $jsonPath;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->jsonPath = new JsonPath([]);
     }

--- a/tests/unit/Common/JsonSchema/JsonPatchTest.php
+++ b/tests/unit/Common/JsonSchema/JsonPatchTest.php
@@ -18,7 +18,7 @@ class JsonPatchTest extends TestCase
 
             $actual = JsonPatch::diff($fixture->doc, $fixture->expected);
 
-            $this->assertEquals(
+            self::assertEquals(
                 json_encode($fixture->patch, JSON_UNESCAPED_SLASHES),
                 json_encode($actual, JSON_UNESCAPED_SLASHES),
                 isset($fixture->comment) ? sprintf("Failed asserting test: %s\n", $fixture->comment) : ''

--- a/tests/unit/Common/JsonSchema/SchemaTest.php
+++ b/tests/unit/Common/JsonSchema/SchemaTest.php
@@ -35,7 +35,7 @@ class SchemaTest extends TestCase
             ->shouldBeCalled()
             ->willReturn([]);
 
-        $this->assertEquals([], $this->schema->getErrors());
+        self::assertEquals([], $this->schema->getErrors());
     }
 
     public function test_it_gets_error_string()
@@ -46,12 +46,12 @@ class SchemaTest extends TestCase
 
         $errorMsg = sprintf("Provided values do not validate. Errors:\n[foo] bar\n");
 
-        $this->assertEquals($errorMsg, $this->schema->getErrorString());
+        self::assertEquals($errorMsg, $this->schema->getErrorString());
     }
 
     public function test_it_gets_property_paths()
     {
-        $this->assertEquals(['/foo', '/bar', '/baz'], $this->schema->getPropertyPaths());
+        self::assertEquals(['/foo', '/bar', '/baz'], $this->schema->getPropertyPaths());
     }
 
     public function test_it_ignores_readOnly_attrs()
@@ -67,7 +67,7 @@ class SchemaTest extends TestCase
             'baz' => true,
         ];
 
-        $this->assertEquals((object)$expected, $this->schema->normalizeObject((object)$subject, []));
+        self::assertEquals((object)$expected, $this->schema->normalizeObject((object)$subject, []));
     }
 
     public function test_it_stocks_aliases()
@@ -83,7 +83,7 @@ class SchemaTest extends TestCase
             'bar' => false,
         ];
 
-        $this->assertEquals($expected, $this->schema->normalizeObject($subject, ['foo' => 'fooAlias', 'bar' => 'lol']));
+        self::assertEquals($expected, $this->schema->normalizeObject($subject, ['foo' => 'fooAlias', 'bar' => 'lol']));
     }
 
     public function test_it_validates()

--- a/tests/unit/Common/JsonSchema/SchemaTest.php
+++ b/tests/unit/Common/JsonSchema/SchemaTest.php
@@ -15,7 +15,7 @@ class SchemaTest extends TestCase
     private $validator;
     private $body;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->body = [
             'properties' => [

--- a/tests/unit/Common/Resource/AbstractResourceTest.php
+++ b/tests/unit/Common/Resource/AbstractResourceTest.php
@@ -31,7 +31,7 @@ class AbstractResourceTest extends TestCase
 
         $this->resource->populateFromResponse($response);
 
-        $this->assertEquals('1', $this->resource->bar);
+        self::assertEquals('1', $this->resource->bar);
     }
 
     public function test_it_populates_datetimes_from_arrays()
@@ -42,8 +42,8 @@ class AbstractResourceTest extends TestCase
         $this->resource->populateFromArray(['created_at' => '2015']);
         $this->resource->populateFromArray(['updated_at' => '2016']);
 
-        $this->assertEquals($this->resource->createdAt, $ca);
-        $this->assertEquals($this->resource->updatedAt, $ua);
+        self::assertEquals($this->resource->createdAt, $ca);
+        self::assertEquals($this->resource->updatedAt, $ua);
     }
 
     public function test_it_populates_model_objects_from_arrays()
@@ -51,31 +51,31 @@ class AbstractResourceTest extends TestCase
         $tr = new TestResource();
         $this->resource->populateFromArray(['child' => $tr]);
 
-        $this->assertEquals($this->resource->child, $tr);
+        self::assertEquals($this->resource->child, $tr);
     }
 
     public function test_it_populates_arrays_from_arrays()
     {
         $this->resource->populateFromArray(['children' => [$this->resource, $this->resource]]);
 
-        $this->assertInstanceOf(TestResource::class, $this->resource->children[0]);
+        self::assertInstanceOf(TestResource::class, $this->resource->children[0]);
     }
 
     public function test_it_gets_attrs()
     {
         $this->resource->bar = 'foo';
 
-        $this->assertEquals(['bar' => 'foo'], $this->resource->getAttrs(['bar']));
+        self::assertEquals(['bar' => 'foo'], $this->resource->getAttrs(['bar']));
     }
 
     public function test_it_returns_a_model_instance()
     {
-        $this->assertInstanceOf(ResourceInterface::class, $this->resource->model(TestResource::class));
+        self::assertInstanceOf(ResourceInterface::class, $this->resource->model(TestResource::class));
     }
 
     public function test_it_populates_models_from_response()
     {
-        $this->assertInstanceOf(ResourceInterface::class, $this->resource->model(TestResource::class, new Response(200)));
+        self::assertInstanceOf(ResourceInterface::class, $this->resource->model(TestResource::class, new Response(200)));
     }
 
     public function test_it_populates_models_from_arrays()
@@ -93,22 +93,22 @@ class AbstractResourceTest extends TestCase
         /** @var TestResource $model */
         $model = $this->resource->model(TestResource::class, $data);
 
-        $this->assertInstanceOf(ResourceInterface::class, $model);
+        self::assertInstanceOf(ResourceInterface::class, $model);
 
-        $this->assertEquals('this-is-bar', $model->bar);
-        $this->assertEquals('this-is-camel-attr', $model->camelAttr);
+        self::assertEquals('this-is-bar', $model->bar);
+        self::assertEquals('this-is-camel-attr', $model->camelAttr);
 
         $child = $model->child;
-        $this->assertInstanceOf(TestResource::class, $child);
-        $this->assertEquals('child-bar', $child->bar);
-        $this->assertEquals('child-camel', $child->camelAttr);
+        self::assertInstanceOf(TestResource::class, $child);
+        self::assertEquals('child-bar', $child->bar);
+        self::assertEquals('child-camel', $child->camelAttr);
 
-        $this->assertContainsOnlyInstancesOf(TestResource::class, $model->children);
-        $this->assertCount(2, $model->children);
-        $this->assertEquals('child1-bar', $model->children[0]->bar);
-        $this->assertEquals('child1-camel', $model->children[0]->camelAttr);
-        $this->assertEquals('child2-bar', $model->children[1]->bar);
-        $this->assertEquals('child2-camel', $model->children[1]->camelAttr);
+        self::assertContainsOnlyInstancesOf(TestResource::class, $model->children);
+        self::assertCount(2, $model->children);
+        self::assertEquals('child1-bar', $model->children[0]->bar);
+        self::assertEquals('child1-camel', $model->children[0]->camelAttr);
+        self::assertEquals('child2-bar', $model->children[1]->bar);
+        self::assertEquals('child2-camel', $model->children[1]->camelAttr);
 
     }
 }

--- a/tests/unit/Common/Resource/AbstractResourceTest.php
+++ b/tests/unit/Common/Resource/AbstractResourceTest.php
@@ -14,7 +14,7 @@ class AbstractResourceTest extends TestCase
     /** @var TestResource */
     private $resource;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Common/Resource/OperatorResourceTest.php
+++ b/tests/unit/Common/Resource/OperatorResourceTest.php
@@ -17,7 +17,7 @@ class OperatorResourceTest extends TestCase
     /** @var TestOperatorResource */
     private $resource;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Common/Resource/OperatorResourceTest.php
+++ b/tests/unit/Common/Resource/OperatorResourceTest.php
@@ -33,8 +33,8 @@ class OperatorResourceTest extends TestCase
 
         $uri = $this->resource->testBaseUri();
 
-        $this->assertInstanceOf(Uri::class, $uri);
-        $this->assertEquals($returnedUri, $uri);
+        self::assertInstanceOf(Uri::class, $uri);
+        self::assertEquals($returnedUri, $uri);
     }
 
     public function test_it_executes_with_state()
@@ -67,10 +67,10 @@ class OperatorResourceTest extends TestCase
 
         foreach ($this->resource->enumerate($api->getServers()) as $item) {
             ++$count;
-            $this->assertInstanceOf(TestOperatorResource::class, $item);
+            self::assertInstanceOf(TestOperatorResource::class, $item);
         }
 
-        $this->assertEquals(5, $count);
+        self::assertEquals(5, $count);
     }
 
     public function test_it_invokes_function_if_provided()
@@ -96,7 +96,7 @@ class OperatorResourceTest extends TestCase
         foreach ($this->resource->enumerate($api->getServers(), [], $fn) as $item) {
         }
 
-        $this->assertEquals(5, $count);
+        self::assertEquals(5, $count);
     }
 
     public function test_it_halts_when_user_provided_limit_is_reached()
@@ -114,7 +114,7 @@ class OperatorResourceTest extends TestCase
             ++$count;
         }
 
-        $this->assertEquals(2, $count);
+        self::assertEquals(2, $count);
     }
 
     public function test_it_predicts_resources_key_without_explicit_property()
@@ -133,7 +133,7 @@ class OperatorResourceTest extends TestCase
             ++$count;
         }
 
-        $this->assertEquals(2, $count);
+        self::assertEquals(2, $count);
     }
 
     public function test_it_extracts_multiple_instances()
@@ -144,24 +144,24 @@ class OperatorResourceTest extends TestCase
         $resources = $resource->extractMultipleInstances($response);
 
         foreach ($resources as $resource) {
-            $this->assertInstanceOf(Server::class, $resource);
+            self::assertInstanceOf(Server::class, $resource);
         }
     }
 
     public function test_it_finds_parent_service()
     {
         $r = new Foo($this->client->reveal(), new Api());
-        $this->assertInstanceOf(Service::class, $r->testGetService());
+        self::assertInstanceOf(Service::class, $r->testGetService());
     }
 
     public function test_it_returns_a_model_instance()
     {
-        $this->assertInstanceOf(ResourceInterface::class, $this->resource->model(TestResource::class));
+        self::assertInstanceOf(ResourceInterface::class, $this->resource->model(TestResource::class));
     }
 
     public function test_it_populates_models_from_response()
     {
-        $this->assertInstanceOf(ResourceInterface::class, $this->resource->model(TestResource::class, new Response(200)));
+        self::assertInstanceOf(ResourceInterface::class, $this->resource->model(TestResource::class, new Response(200)));
     }
 
     public function test_it_populates_models_from_arrays()
@@ -174,9 +174,9 @@ class OperatorResourceTest extends TestCase
         /** @var TestOperatorResource $model */
         $model = $this->resource->model(TestOperatorResource::class, $data);
 
-        $this->assertInstanceOf(ResourceInterface::class, $model);
-        $this->assertEquals(123, $model->id);
-        $this->assertEquals('this-is-bar', $model->bar);
+        self::assertInstanceOf(ResourceInterface::class, $model);
+        self::assertEquals(123, $model->id);
+        self::assertEquals('this-is-bar', $model->bar);
     }
 }
 

--- a/tests/unit/Common/Service/BuilderTest.php
+++ b/tests/unit/Common/Service/BuilderTest.php
@@ -15,7 +15,7 @@ class BuilderTest extends TestCase
     private $builder;
     private $opts;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->builder = new Builder([]);
 
@@ -30,65 +30,54 @@ class BuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_it_throws_exception_if_username_is_missing()
     {
+		$this->expectException(\Exception::class);
         $this->builder->createService('Compute\\v2', []);
     }
 
-    /**
-     * @expectedException \Throwable
-     */
     public function test_it_throws_exception_if_password_is_missing()
     {
+		$this->expectException(\Exception::class);
         $this->builder->createService('Compute\\v2', ['username' => 1]);
     }
 
-    /**
-     * @expectedException \Throwable
-     */
     public function test_it_throws_exception_if_both_tenantId_and_tenantName_is_missing()
     {
+		$this->expectException(\Throwable::class);
         $this->builder->createService('Compute\\v2', [
             'username' => 1, 'password' => 2, 'authUrl' => 4, 'region' => 5, 'catalogName' => 6, 'catalogType' => 7,
         ]);
     }
 
-    /**
-     * @expectedException \Throwable
-     */
     public function test_it_throws_exception_if_authUrl_is_missing()
     {
+		$this->expectException(\Throwable::class);
         $this->builder->createService('Compute\\v2', ['username' => 1, 'password' => 2, 'tenantId' => 3]);
     }
 
-    /**
-     * @expectedException \Throwable
-     */
     public function test_it_throws_exception_if_region_is_missing()
     {
+		$this->expectException(\Throwable::class);
+
         $this->builder->createService('Compute\\v2', [
             'username' => 1, 'password' => 2, 'tenantId' => 3, 'authUrl' => 4,
         ]);
     }
 
-    /**
-     * @expectedException \Throwable
-     */
     public function test_it_throws_exception_if_catalogName_is_missing()
     {
+		$this->expectException(\Throwable::class);
+
         $this->builder->createService('Compute\\v2', [
             'username' => 1, 'password' => 2, 'tenantId' => 3, 'authUrl' => 4,
         ]);
     }
 
-    /**
-     * @expectedException \Throwable
-     */
     public function test_it_throws_exception_if_catalogType_is_missing()
     {
+		$this->expectException(\Throwable::class);
+
         $this->builder->createService('Compute\\v2', [
             'username' => 1, 'password' => 2, 'tenantId' => 3, 'authUrl' => 4, 'region' => 5, 'catalogName' => 6,
         ]);

--- a/tests/unit/Common/Service/BuilderTest.php
+++ b/tests/unit/Common/Service/BuilderTest.php
@@ -92,7 +92,7 @@ class BuilderTest extends TestCase
             'identityService' => $is->reveal(),
         ]);
 
-        $this->assertInstanceOf(Fixtures\Service::class, $s);
+        self::assertInstanceOf(Fixtures\Service::class, $s);
     }
 
     public function test_it_does_not_authenticate_for_identity_services()
@@ -104,7 +104,7 @@ class BuilderTest extends TestCase
             'identityService' => $is->reveal(),
         ]);
 
-        $this->assertInstanceOf(Fixtures\Identity\Service::class, $s);
+        self::assertInstanceOf(Fixtures\Identity\Service::class, $s);
     }
 
     public function test_it_create_service_with_micro_version()
@@ -117,7 +117,7 @@ class BuilderTest extends TestCase
                 'microVersion' => '1.2.3'
             ]);
 
-        $this->assertInstanceOf(Fixtures\Service::class, $s);
+        self::assertInstanceOf(Fixtures\Service::class, $s);
 
         $refClass = new \ReflectionClass($s);
         $refProperty = $refClass->getProperty('client');
@@ -127,8 +127,8 @@ class BuilderTest extends TestCase
         $client = $refProperty->getValue($s);
 
         $headers = $client->getConfig()['headers'];
-        $this->assertArrayHasKey('OpenStack-API-Version', $headers);
-        $this->assertEquals('7 1.2.3', $headers['OpenStack-API-Version']);
+        self::assertArrayHasKey('OpenStack-API-Version', $headers);
+        self::assertEquals('7 1.2.3', $headers['OpenStack-API-Version']);
     }
 }
 

--- a/tests/unit/Common/Transport/HandlerStackTest.php
+++ b/tests/unit/Common/Transport/HandlerStackTest.php
@@ -10,6 +10,6 @@ class HandlerStackTest extends TestCase
 {
     public function test_it_is_created()
     {
-        $this->assertInstanceOf(HandlerStack::class, HandlerStack::create(new MockHandler()));
+        self::assertInstanceOf(HandlerStack::class, HandlerStack::create(new MockHandler()));
     }
 }

--- a/tests/unit/Common/Transport/JsonSerializerTest.php
+++ b/tests/unit/Common/Transport/JsonSerializerTest.php
@@ -13,7 +13,7 @@ class JsonSerializerTest extends \PHPUnit\Framework\TestCase
     /** @var JsonSerializer */
     private $serializer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->serializer = new JsonSerializer();
     }
@@ -145,9 +145,6 @@ class JsonSerializerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $json);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function test_exception_is_thrown_when_non_stdClass_or_serializable_object_provided()
     {
         $subParam = $this->prophesize(Parameter::class);
@@ -160,6 +157,7 @@ class JsonSerializerTest extends \PHPUnit\Framework\TestCase
         $param->getProperty('subResource')->shouldBeCalled()->willReturn($subParam);
 
         $userValues = ['subResource' => new NonSerializableResource()];
+		$this->expectException(\InvalidArgumentException::class);
 
         $this->serializer->stockJson($param->reveal(), $userValues, []);
     }

--- a/tests/unit/Common/Transport/JsonSerializerTest.php
+++ b/tests/unit/Common/Transport/JsonSerializerTest.php
@@ -38,7 +38,7 @@ class JsonSerializerTest extends \PHPUnit\Framework\TestCase
 
         $actual = $this->serializer->stockJson($param->reveal(), $userValue, []);
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function test_it_serializes_arrays()
@@ -62,7 +62,7 @@ class JsonSerializerTest extends \PHPUnit\Framework\TestCase
 
         $actual = $this->serializer->stockJson($param->reveal(), $userValues, []);
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function test_it_serializes_objects()
@@ -84,7 +84,7 @@ class JsonSerializerTest extends \PHPUnit\Framework\TestCase
 
         $json = $this->serializer->stockJson($param->reveal(), (object)['foo' => true], []);
 
-        $this->assertEquals($expected, $json);
+        self::assertEquals($expected, $json);
     }
 
     public function test_it_serializes_non_stdClass_objects()
@@ -142,7 +142,7 @@ class JsonSerializerTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $json);
+        self::assertEquals($expected, $json);
     }
 
     public function test_exception_is_thrown_when_non_stdClass_or_serializable_object_provided()

--- a/tests/unit/Common/Transport/MiddlewareTest.php
+++ b/tests/unit/Common/Transport/MiddlewareTest.php
@@ -20,7 +20,7 @@ class MiddlewareTest extends TestCase
         $fn = $middleware($handler);
 
         $promise = $fn(new Request('GET', 'http://foo.com'), []);
-        $this->assertEquals('pending', $promise->getState());
+        self::assertEquals('pending', $promise->getState());
 
 		$this->expectException(BadResponseError::class);
 		$promise->wait();
@@ -37,7 +37,7 @@ class MiddlewareTest extends TestCase
         $promise = $fn(new Request('GET', 'http://foo.com'), []);
 
         $promise->then(function ($val) use ($response) {
-            $this->assertEquals($val, $response);
+            self::assertEquals($val, $response);
         });
 
         $promise->wait();
@@ -53,6 +53,6 @@ class MiddlewareTest extends TestCase
         $handler  = new MockHandler([new Response(204)]);
         $fn = $middleware($handler);
 
-        $this->assertInstanceOf(AuthHandler::class, $fn);
+        self::assertInstanceOf(AuthHandler::class, $fn);
     }
 }

--- a/tests/unit/Common/Transport/MiddlewareTest.php
+++ b/tests/unit/Common/Transport/MiddlewareTest.php
@@ -5,15 +5,13 @@ namespace unit\Common\Transport;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use OpenStack\Common\Error\BadResponseError;
 use OpenStack\Common\Transport\Middleware;
 use OpenStack\Test\TestCase;
 use OpenStack\Common\Auth\AuthHandler;
 
 class MiddlewareTest extends TestCase
 {
-    /**
-     * @expectedException \OpenStack\Common\Error\BadResponseError
-     */
     public function test_exception_is_thrown_for_4xx_statuses()
     {
         $middleware = Middleware::httpErrors();
@@ -24,8 +22,8 @@ class MiddlewareTest extends TestCase
         $promise = $fn(new Request('GET', 'http://foo.com'), []);
         $this->assertEquals('pending', $promise->getState());
 
-        $promise->wait();
-        $this->assertEquals('rejected', $promise->getState());
+		$this->expectException(BadResponseError::class);
+		$promise->wait();
     }
 
     public function test_responses_are_left_alone_when_status_under_400()

--- a/tests/unit/Common/Transport/RequestSerializerTest.php
+++ b/tests/unit/Common/Transport/RequestSerializerTest.php
@@ -13,7 +13,7 @@ class RequestSerializerTest extends TestCase
     private $rs;
     private $js;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->js = $this->prophesize(JsonSerializer::class);
 

--- a/tests/unit/Common/Transport/RequestSerializerTest.php
+++ b/tests/unit/Common/Transport/RequestSerializerTest.php
@@ -25,7 +25,7 @@ class RequestSerializerTest extends TestCase
         $op = $this->prophesize(Operation::class);
         $op->getParam('foo')->shouldBeCalled()->willReturn(null);
 
-        $this->assertEquals(['headers' => []], $this->rs->serializeOptions($op->reveal(), ['foo' => 'bar']));
+        self::assertEquals(['headers' => []], $this->rs->serializeOptions($op->reveal(), ['foo' => 'bar']));
     }
 
     public function test_it_serializes_queries()
@@ -40,7 +40,7 @@ class RequestSerializerTest extends TestCase
         $actual = $this->rs->serializeOptions($op->reveal(), ['foo' => 'bar']);
         $expected = ['query' => ['fooAlias' => 'bar'], 'headers' => []];
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function test_it_serializes_headers()
@@ -56,7 +56,7 @@ class RequestSerializerTest extends TestCase
         $actual = $this->rs->serializeOptions($op->reveal(), ['foo' => 'bar']);
         $expected = ['headers' => ['prefix-fooAlias' => 'bar']];
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function test_it_serializes_metadata_headers()
@@ -76,7 +76,7 @@ class RequestSerializerTest extends TestCase
         $actual = $this->rs->serializeOptions($op->reveal(), ['metadata' => ['foo' => 'bar']]);
         $expected = ['headers' => ['prefix-foo' => 'bar']];
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function test_it_serializes_json()
@@ -93,7 +93,7 @@ class RequestSerializerTest extends TestCase
         $actual = $this->rs->serializeOptions($op->reveal(), ['foo' => 'bar']);
         $expected = ['json' => ['jsonKey' => ['foo' => 'bar']], 'headers' => []];
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function test_it_serializes_unescaped_json()
@@ -110,7 +110,7 @@ class RequestSerializerTest extends TestCase
         $actual = $this->rs->serializeOptions($op->reveal(), ['foo' => 'bar/baz']);
         $expected = ['body' => '{"foo":"bar/baz"}', 'headers' => ['Content-Type' => 'application/json']];
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function test_it_serializes_raw_vals()
@@ -124,7 +124,7 @@ class RequestSerializerTest extends TestCase
         $actual = $this->rs->serializeOptions($op->reveal(), ['foo' => 'bar']);
         $expected = ['body' => 'bar', 'headers' => []];
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function test_it_does_serialize_unknown_locations()
@@ -138,6 +138,6 @@ class RequestSerializerTest extends TestCase
         $actual = $this->rs->serializeOptions($op->reveal(), ['foo' => 'bar']);
         $expected = ['headers' => []];
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }

--- a/tests/unit/Common/Transport/UtilsTest.php
+++ b/tests/unit/Common/Transport/UtilsTest.php
@@ -10,12 +10,10 @@ use OpenStack\Test\TestCase;
 
 class UtilsTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function test_decoding_malformed_json_throws_error()
     {
         $response = new Response(200, [], \GuzzleHttp\Psr7\stream_for('{'));
+		$this->expectException(\InvalidArgumentException::class);
 
         Utils::jsonDecode($response);
     }

--- a/tests/unit/Common/Transport/UtilsTest.php
+++ b/tests/unit/Common/Transport/UtilsTest.php
@@ -22,7 +22,7 @@ class UtilsTest extends TestCase
     {
         $uri = Utils::addPaths(uri_for('http://openstack.org/foo'), 'bar', 'baz', '1', '2');
 
-        $this->assertInstanceOf(Uri::class, $uri);
-        $this->assertEquals(uri_for('http://openstack.org/foo/bar/baz/1/2'), $uri);
+        self::assertInstanceOf(Uri::class, $uri);
+        self::assertEquals(uri_for('http://openstack.org/foo/bar/baz/1/2'), $uri);
     }
 }

--- a/tests/unit/Compute/v2/Models/FlavorTest.php
+++ b/tests/unit/Compute/v2/Models/FlavorTest.php
@@ -11,7 +11,7 @@ class FlavorTest extends TestCase
 {
     private $flavor;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Compute/v2/Models/FlavorTest.php
+++ b/tests/unit/Compute/v2/Models/FlavorTest.php
@@ -27,11 +27,11 @@ class FlavorTest extends TestCase
 
         $this->flavor->retrieve();
 
-        $this->assertEquals('m1.tiny', $this->flavor->name);
-        $this->assertEquals('1', $this->flavor->id);
-        $this->assertEquals(512, $this->flavor->ram);
-        $this->assertEquals(1, $this->flavor->vcpus);
-        $this->assertEquals(1, $this->flavor->disk);
+        self::assertEquals('m1.tiny', $this->flavor->name);
+        self::assertEquals('1', $this->flavor->id);
+        self::assertEquals(512, $this->flavor->ram);
+        self::assertEquals(1, $this->flavor->vcpus);
+        self::assertEquals(1, $this->flavor->disk);
     }
 
     public function test_it_creates()
@@ -52,7 +52,7 @@ class FlavorTest extends TestCase
 
         $this->setupMock('POST', 'flavors', $expectedJson, [], 'flavor-post');
 
-        $this->assertInstanceOf(Flavor::class, $this->flavor->create($opts));
+        self::assertInstanceOf(Flavor::class, $this->flavor->create($opts));
     }
 
     public function test_it_deletes()

--- a/tests/unit/Compute/v2/Models/HostTest.php
+++ b/tests/unit/Compute/v2/Models/HostTest.php
@@ -28,6 +28,6 @@ class HostTest extends TestCase
 
         $this->host->retrieve();
 
-        $this->assertEquals("b6e4adbc193d428ea923899d07fb001e", $this->host->name);
+        self::assertEquals("b6e4adbc193d428ea923899d07fb001e", $this->host->name);
     }
 }

--- a/tests/unit/Compute/v2/Models/HostTest.php
+++ b/tests/unit/Compute/v2/Models/HostTest.php
@@ -12,7 +12,7 @@ class HostTest extends TestCase
     /** @var Host */
     private $host;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Compute/v2/Models/HypervisorTest.php
+++ b/tests/unit/Compute/v2/Models/HypervisorTest.php
@@ -13,7 +13,7 @@ class HypervisorTest extends TestCase
 
     const ID = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Compute/v2/Models/HypervisorTest.php
+++ b/tests/unit/Compute/v2/Models/HypervisorTest.php
@@ -29,21 +29,21 @@ class HypervisorTest extends TestCase
 
         $this->hypervisor->retrieve();
 
-        $this->assertEquals('1', $this->hypervisor->id);
-        $this->assertEquals('enabled', $this->hypervisor->status);
-        $this->assertEquals('up', $this->hypervisor->state);
-        $this->assertEquals('146', $this->hypervisor->freeDiskGb);
-        $this->assertEquals('76917', $this->hypervisor->freeRamMb);
-        $this->assertEquals('localhost.localdomain', $this->hypervisor->hypervisorHostname);
-        $this->assertEquals('QEMU', $this->hypervisor->hypervisorType);
-        $this->assertEquals('2006000', $this->hypervisor->hypervisorVersion);
-        $this->assertEquals('266', $this->hypervisor->localGb);
-        $this->assertEquals('120', $this->hypervisor->localGbUsed);
-        $this->assertEquals('97909', $this->hypervisor->memoryMb);
-        $this->assertEquals('20992', $this->hypervisor->memoryMbUsed);
-        $this->assertEquals('4', $this->hypervisor->runningVms);
-        $this->assertEquals('56', $this->hypervisor->vcpus);
-        $this->assertEquals('10', $this->hypervisor->vcpusUsed);
-        $this->assertEquals(['host' => 'localhost.localdomain', 'id' => '8', 'disabled_reason' => null], $this->hypervisor->service);
+        self::assertEquals('1', $this->hypervisor->id);
+        self::assertEquals('enabled', $this->hypervisor->status);
+        self::assertEquals('up', $this->hypervisor->state);
+        self::assertEquals('146', $this->hypervisor->freeDiskGb);
+        self::assertEquals('76917', $this->hypervisor->freeRamMb);
+        self::assertEquals('localhost.localdomain', $this->hypervisor->hypervisorHostname);
+        self::assertEquals('QEMU', $this->hypervisor->hypervisorType);
+        self::assertEquals('2006000', $this->hypervisor->hypervisorVersion);
+        self::assertEquals('266', $this->hypervisor->localGb);
+        self::assertEquals('120', $this->hypervisor->localGbUsed);
+        self::assertEquals('97909', $this->hypervisor->memoryMb);
+        self::assertEquals('20992', $this->hypervisor->memoryMbUsed);
+        self::assertEquals('4', $this->hypervisor->runningVms);
+        self::assertEquals('56', $this->hypervisor->vcpus);
+        self::assertEquals('10', $this->hypervisor->vcpusUsed);
+        self::assertEquals(['host' => 'localhost.localdomain', 'id' => '8', 'disabled_reason' => null], $this->hypervisor->service);
     }
 }

--- a/tests/unit/Compute/v2/Models/ImageTest.php
+++ b/tests/unit/Compute/v2/Models/ImageTest.php
@@ -11,7 +11,7 @@ class ImageTest extends TestCase
 {
     private $image;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Compute/v2/Models/ImageTest.php
+++ b/tests/unit/Compute/v2/Models/ImageTest.php
@@ -34,14 +34,14 @@ class ImageTest extends TestCase
             "ramdisk_id" => "nokernel"
         ];
 
-        $this->assertEquals(new \DateTimeImmutable('2011-01-01T01:02:03Z'), $this->image->created);
-        $this->assertEquals($metadata, $this->image->metadata);
-        $this->assertEquals(0, $this->image->minDisk);
-        $this->assertEquals(0, $this->image->minRam);
-        $this->assertEquals('fakeimage7', $this->image->name);
-        $this->assertEquals(100, $this->image->progress);
-        $this->assertEquals('ACTIVE', $this->image->status);
-        $this->assertEquals(new \DateTimeImmutable('2011-01-01T01:02:03Z'), $this->image->updated);
+        self::assertEquals(new \DateTimeImmutable('2011-01-01T01:02:03Z'), $this->image->created);
+        self::assertEquals($metadata, $this->image->metadata);
+        self::assertEquals(0, $this->image->minDisk);
+        self::assertEquals(0, $this->image->minRam);
+        self::assertEquals('fakeimage7', $this->image->name);
+        self::assertEquals(100, $this->image->progress);
+        self::assertEquals('ACTIVE', $this->image->status);
+        self::assertEquals(new \DateTimeImmutable('2011-01-01T01:02:03Z'), $this->image->updated);
     }
 
     public function test_it_deletes()
@@ -57,10 +57,10 @@ class ImageTest extends TestCase
 
         $metadata = $this->image->getMetadata();
 
-        $this->assertEquals('x86_64', $metadata['architecture']);
-        $this->assertEquals('True', $metadata['auto_disk_config']);
-        $this->assertEquals('nokernel', $metadata['kernel_id']);
-        $this->assertEquals('nokernel', $metadata['ramdisk_id']);
+        self::assertEquals('x86_64', $metadata['architecture']);
+        self::assertEquals('True', $metadata['auto_disk_config']);
+        self::assertEquals('nokernel', $metadata['kernel_id']);
+        self::assertEquals('nokernel', $metadata['ramdisk_id']);
     }
 
     public function test_it_sets_metadata()
@@ -74,7 +74,7 @@ class ImageTest extends TestCase
 
         $this->image->resetMetadata($metadata);
 
-        $this->assertEquals('1', $this->image->metadata['foo']);
+        self::assertEquals('1', $this->image->metadata['foo']);
     }
 
     public function test_it_updates_metadata()
@@ -88,8 +88,8 @@ class ImageTest extends TestCase
 
         $this->image->mergeMetadata($metadata);
 
-        $this->assertEquals('1', $this->image->metadata['foo']);
-        $this->assertEquals('2', $this->image->metadata['bar']);
+        self::assertEquals('1', $this->image->metadata['foo']);
+        self::assertEquals('2', $this->image->metadata['bar']);
     }
 
     public function test_it_retrieves_a_metadata_item()
@@ -99,13 +99,13 @@ class ImageTest extends TestCase
 
         $value = $this->image->getMetadataItem('fooKey');
 
-        $this->assertEquals('bar', $value);
+        self::assertEquals('bar', $value);
     }
 
     public function test_it_deletes_a_metadata_item()
     {
         $this->setupMock('DELETE', 'images/imageId/metadata/fooKey', null, [], new Response(204));
 
-        $this->assertNull($this->image->deleteMetadataItem('fooKey'));
+        self::assertNull($this->image->deleteMetadataItem('fooKey'));
     }
 }

--- a/tests/unit/Compute/v2/Models/KeypairTest.php
+++ b/tests/unit/Compute/v2/Models/KeypairTest.php
@@ -14,7 +14,7 @@ class KeypairTest extends TestCase
 
     const KEYPAIR_NAME = 'keypair-test';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Compute/v2/Models/KeypairTest.php
+++ b/tests/unit/Compute/v2/Models/KeypairTest.php
@@ -39,7 +39,7 @@ class KeypairTest extends TestCase
 
         $this->setupMock('POST', 'os-keypairs', $expectedJson, ['Content-Type' => 'application/json'], 'keypair-post');
 
-        $this->assertInstanceOf(Keypair::class, $this->keypair->create($opts));
+        self::assertInstanceOf(Keypair::class, $this->keypair->create($opts));
     }
 
     public function test_it_retrieves()
@@ -48,15 +48,15 @@ class KeypairTest extends TestCase
 
         $this->keypair->retrieve();
 
-        $this->assertEquals('1', $this->keypair->id);
-        $this->assertEquals('fake', $this->keypair->userId);
-        $this->assertEquals('44:fe:29:6e:23:14:b9:53:5b:65:82:58:1c:fe:5a:c3', $this->keypair->fingerprint);
-        $this->assertEquals(self::KEYPAIR_NAME, $this->keypair->name);
-        $this->assertEquals(
+        self::assertEquals('1', $this->keypair->id);
+        self::assertEquals('fake', $this->keypair->userId);
+        self::assertEquals('44:fe:29:6e:23:14:b9:53:5b:65:82:58:1c:fe:5a:c3', $this->keypair->fingerprint);
+        self::assertEquals(self::KEYPAIR_NAME, $this->keypair->name);
+        self::assertEquals(
             'ssh-rsa AAAAAAABBBBBBBBBCCCCCCCCCCC foo@bar.com',
             $this->keypair->publicKey
         );
-        $this->assertFalse($this->keypair->deleted);
+        self::assertFalse($this->keypair->deleted);
     }
 
     public function test_it_retrieves_by_user_id()
@@ -70,15 +70,15 @@ class KeypairTest extends TestCase
         $this->keypair->userId = 'fake';
         $this->keypair->retrieve();
 
-        $this->assertEquals('1', $this->keypair->id);
-        $this->assertEquals('fake', $this->keypair->userId);
-        $this->assertEquals('44:fe:29:6e:23:14:b9:53:5b:65:82:58:1c:fe:5a:c3', $this->keypair->fingerprint);
-        $this->assertEquals(self::KEYPAIR_NAME, $this->keypair->name);
-        $this->assertEquals(
+        self::assertEquals('1', $this->keypair->id);
+        self::assertEquals('fake', $this->keypair->userId);
+        self::assertEquals('44:fe:29:6e:23:14:b9:53:5b:65:82:58:1c:fe:5a:c3', $this->keypair->fingerprint);
+        self::assertEquals(self::KEYPAIR_NAME, $this->keypair->name);
+        self::assertEquals(
             'ssh-rsa AAAAAAABBBBBBBBBCCCCCCCCCCC foo@bar.com',
             $this->keypair->publicKey
         );
-        $this->assertFalse($this->keypair->deleted);
+        self::assertFalse($this->keypair->deleted);
     }
 
     public function test_it_deletes()

--- a/tests/unit/Compute/v2/Models/QuotaSetTest.php
+++ b/tests/unit/Compute/v2/Models/QuotaSetTest.php
@@ -30,22 +30,22 @@ class QuotaSetTest extends TestCase
 
         $this->quotaSet->retrieve();
 
-        $this->assertEquals(10240, $this->quotaSet->injectedFileContentBytes);
-        $this->assertEquals(128, $this->quotaSet->metadataItems);
-        $this->assertEquals(22, $this->quotaSet->serverGroupMembers);
-        $this->assertEquals(10, $this->quotaSet->serverGroups);
-        $this->assertEquals(51200, $this->quotaSet->ram);
-        $this->assertEquals(33, $this->quotaSet->floatingIps);
-        $this->assertEquals(100, $this->quotaSet->keyPairs);
-        $this->assertEquals(999, $this->quotaSet->instances);
-        $this->assertEquals(20, $this->quotaSet->securityGroupRules);
-        $this->assertEquals(5, $this->quotaSet->injectedFiles);
-        $this->assertEquals(500, $this->quotaSet->cores);
-        $this->assertEquals(-1, $this->quotaSet->fixedIps);
-        $this->assertEquals(255, $this->quotaSet->injectedFilePathBytes);
-        $this->assertEquals(10, $this->quotaSet->securityGroups);
+        self::assertEquals(10240, $this->quotaSet->injectedFileContentBytes);
+        self::assertEquals(128, $this->quotaSet->metadataItems);
+        self::assertEquals(22, $this->quotaSet->serverGroupMembers);
+        self::assertEquals(10, $this->quotaSet->serverGroups);
+        self::assertEquals(51200, $this->quotaSet->ram);
+        self::assertEquals(33, $this->quotaSet->floatingIps);
+        self::assertEquals(100, $this->quotaSet->keyPairs);
+        self::assertEquals(999, $this->quotaSet->instances);
+        self::assertEquals(20, $this->quotaSet->securityGroupRules);
+        self::assertEquals(5, $this->quotaSet->injectedFiles);
+        self::assertEquals(500, $this->quotaSet->cores);
+        self::assertEquals(-1, $this->quotaSet->fixedIps);
+        self::assertEquals(255, $this->quotaSet->injectedFilePathBytes);
+        self::assertEquals(10, $this->quotaSet->securityGroups);
 
-        $this->assertEquals(self::TENANT_ID, $this->quotaSet->tenantId);
+        self::assertEquals(self::TENANT_ID, $this->quotaSet->tenantId);
     }
 
     public function test_it_deletes()

--- a/tests/unit/Compute/v2/Models/QuotaSetTest.php
+++ b/tests/unit/Compute/v2/Models/QuotaSetTest.php
@@ -14,7 +14,7 @@ class QuotaSetTest extends TestCase
 
     const TENANT_ID = 'fake-tenant-id';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Compute/v2/Models/ServerTest.php
+++ b/tests/unit/Compute/v2/Models/ServerTest.php
@@ -41,7 +41,7 @@ class ServerTest extends TestCase
         ]];
 
         $this->setupMock('POST', 'servers', $expectedJson, [], 'server-post');
-        $this->assertInstanceOf(Server::class, $this->server->create($opts));
+        self::assertInstanceOf(Server::class, $this->server->create($opts));
     }
 
     public function test_it_creates_with_boot_from_volume()
@@ -59,7 +59,7 @@ class ServerTest extends TestCase
         ]];
 
         $this->setupMock('POST', 'servers', $expectedJson, [], 'server-post');
-        $this->assertInstanceOf(Server::class, $this->server->create($opts));
+        self::assertInstanceOf(Server::class, $this->server->create($opts));
     }
 
     public function test_it_requires_image_id_or_volume_id_to_create_servers()
@@ -94,7 +94,7 @@ class ServerTest extends TestCase
     {
         $this->setupMock('DELETE', 'servers/serverId', null, [], new Response(204));
 
-        $this->assertNull($this->server->delete());
+        self::assertNull($this->server->delete());
     }
 
     public function test_it_retrieves()
@@ -103,8 +103,8 @@ class ServerTest extends TestCase
 
         $this->server->retrieve();
 
-        $this->assertInstanceOf(Flavor::class, $this->server->flavor);
-        $this->assertEquals("1", $this->server->flavor->id);
+        self::assertInstanceOf(Flavor::class, $this->server->flavor);
+        self::assertEquals("1", $this->server->flavor->id);
     }
 
     public function test_it_changes_password()
@@ -112,7 +112,7 @@ class ServerTest extends TestCase
         $expectedJson = ['changePassword' => ['adminPass' => 'foo']];
         $this->setupMock('POST', 'servers/serverId/action', $expectedJson, [], new Response(202));
 
-        $this->assertNull($this->server->changePassword('foo'));
+        self::assertNull($this->server->changePassword('foo'));
     }
 
     public function test_it_reboots()
@@ -120,7 +120,7 @@ class ServerTest extends TestCase
         $expectedJson = ["reboot" => ["type" => "SOFT"]];
         $this->setupMock('POST', 'servers/serverId/action', $expectedJson, [], new Response(202));
 
-        $this->assertNull($this->server->reboot());
+        self::assertNull($this->server->reboot());
     }
 
     public function test_an_exception_is_thrown_when_rebooting_with_an_invalid_type()
@@ -159,8 +159,8 @@ class ServerTest extends TestCase
 
         $this->server->rebuild($userOptions);
 
-        $this->assertEquals($userOptions['imageId'], $this->server->image->id);
-        $this->assertEquals($userOptions['name'], $this->server->name);
+        self::assertEquals($userOptions['imageId'], $this->server->image->id);
+        self::assertEquals($userOptions['name'], $this->server->name);
     }
 
     public function test_it_rescues()
@@ -181,7 +181,7 @@ class ServerTest extends TestCase
 
         $adminPass = $this->server->rescue($userOptions);
 
-        $this->assertEquals('foo', $adminPass);
+        self::assertEquals('foo', $adminPass);
     }
 
     public function test_it_unrescues()
@@ -190,7 +190,7 @@ class ServerTest extends TestCase
 
         $this->setupMock('POST', 'servers/serverId/action', $expectedJson, [], 'server-unrescue');
 
-        $this->assertNull($this->server->unrescue());
+        self::assertNull($this->server->unrescue());
     }
 
     public function test_it_starts()
@@ -199,7 +199,7 @@ class ServerTest extends TestCase
 
         $this->setupMock('POST', 'servers/serverId/action', $expectedJson, [], new Response(202));
 
-        $this->assertNull($this->server->start());
+        self::assertNull($this->server->start());
     }
 
     public function test_it_stops()
@@ -208,7 +208,7 @@ class ServerTest extends TestCase
 
         $this->setupMock('POST', 'servers/serverId/action', $expectedJson, [], new Response(202));
 
-        $this->assertNull($this->server->stop());
+        self::assertNull($this->server->stop());
     }
 
     public function test_it_resizes()
@@ -216,7 +216,7 @@ class ServerTest extends TestCase
         $expectedJson = ['resize' => ['flavorRef' => 'flavorId']];
         $this->setupMock('POST', 'servers/serverId/action', $expectedJson, [], new Response(202));
 
-        $this->assertNull($this->server->resize('flavorId'));
+        self::assertNull($this->server->resize('flavorId'));
     }
 
     public function test_it_confirms_resizes()
@@ -224,7 +224,7 @@ class ServerTest extends TestCase
         $expectedJson = ['confirmResize' => null];
         $this->setupMock('POST', 'servers/serverId/action', $expectedJson, [], new Response(202));
 
-        $this->assertNull($this->server->confirmResize());
+        self::assertNull($this->server->confirmResize());
     }
 
     public function test_it_reverts_resizes()
@@ -232,7 +232,7 @@ class ServerTest extends TestCase
         $expectedJson = ['revertResize' => null];
         $this->setupMock('POST', 'servers/serverId/action', $expectedJson, [], new Response(202));
 
-        $this->assertNull($this->server->revertResize());
+        self::assertNull($this->server->revertResize());
     }
 
     public function test_it_gets_console_output()
@@ -240,7 +240,7 @@ class ServerTest extends TestCase
         $expectedJson = ["os-getConsoleOutput" => ["length" => 3]];
         $this->setupMock('POST', 'servers/serverId/action', $expectedJson, [], 'server-get-console-output');
 
-        $this->assertEquals("FAKE CONSOLE OUTPUT\nANOTHER\nLAST LINE", $this->server->getConsoleOutput(3));
+        self::assertEquals("FAKE CONSOLE OUTPUT\nANOTHER\nLAST LINE", $this->server->getConsoleOutput(3));
     }
 
     public function test_it_gets_all_console_output()
@@ -248,7 +248,7 @@ class ServerTest extends TestCase
         $expectedJson = ["os-getConsoleOutput" => new \stdClass()];
         $this->setupMock('POST', 'servers/serverId/action', $expectedJson, [], 'server-get-console-output');
 
-        $this->assertEquals("FAKE CONSOLE OUTPUT\nANOTHER\nLAST LINE", $this->server->getConsoleOutput());
+        self::assertEquals("FAKE CONSOLE OUTPUT\nANOTHER\nLAST LINE", $this->server->getConsoleOutput());
     }
 
     public function test_it_gets_vnc_console()
@@ -260,9 +260,9 @@ class ServerTest extends TestCase
 
         $response = $this->server->getVncConsole();
 
-        $this->assertArrayHasKey('url', $response);
-        $this->assertArrayHasKey('type', $response);
-        $this->assertEquals($type, $response['type']);
+        self::assertArrayHasKey('url', $response);
+        self::assertArrayHasKey('type', $response);
+        self::assertEquals($type, $response['type']);
     }
 
     public function test_it_gets_rdp_console()
@@ -274,9 +274,9 @@ class ServerTest extends TestCase
 
         $response = $this->server->getRDPConsole();
 
-        $this->assertArrayHasKey('url', $response);
-        $this->assertArrayHasKey('type', $response);
-        $this->assertEquals($type, $response['type']);
+        self::assertArrayHasKey('url', $response);
+        self::assertArrayHasKey('type', $response);
+        self::assertEquals($type, $response['type']);
     }
 
     public function test_it_gets_spice_console()
@@ -288,9 +288,9 @@ class ServerTest extends TestCase
 
         $response = $this->server->getSpiceConsole();
 
-        $this->assertArrayHasKey('url', $response);
-        $this->assertArrayHasKey('type', $response);
-        $this->assertEquals($type, $response['type']);
+        self::assertArrayHasKey('url', $response);
+        self::assertArrayHasKey('type', $response);
+        self::assertEquals($type, $response['type']);
     }
 
     public function test_it_gets_serial_console()
@@ -302,9 +302,9 @@ class ServerTest extends TestCase
 
         $response = $this->server->getSerialConsole();
 
-        $this->assertArrayHasKey('url', $response);
-        $this->assertArrayHasKey('type', $response);
-        $this->assertEquals($type, $response['type']);
+        self::assertArrayHasKey('url', $response);
+        self::assertArrayHasKey('type', $response);
+        self::assertEquals($type, $response['type']);
     }
 
     public function test_it_creates_images()
@@ -314,7 +314,7 @@ class ServerTest extends TestCase
         $expectedJson = ['createImage' => $userData];
         $this->setupMock('POST', 'servers/serverId/action', $expectedJson, [], new Response(202));
 
-        $this->assertNull($this->server->createImage($userData));
+        self::assertNull($this->server->createImage($userData));
     }
 
     public function test_it_gets_ip_addresses()
@@ -324,8 +324,8 @@ class ServerTest extends TestCase
         $ips = $this->server->listAddresses();
 
         self::assertIsArray($ips);
-        $this->assertCount(4, $ips['public']);
-        $this->assertCount(2, $ips['private']);
+        self::assertCount(4, $ips['public']);
+        self::assertCount(2, $ips['private']);
     }
 
     public function test_it_gets_ip_addresses_by_network_label()
@@ -335,8 +335,8 @@ class ServerTest extends TestCase
         $ips = $this->server->listAddresses(['networkLabel' => 'foo']);
 
         self::assertIsArray($ips);
-        $this->assertCount(4, $ips['public']);
-        $this->assertCount(2, $ips['private']);
+        self::assertCount(4, $ips['public']);
+        self::assertCount(2, $ips['private']);
     }
 
     public function test_it_retrieves_metadata()
@@ -345,10 +345,10 @@ class ServerTest extends TestCase
 
         $metadata = $this->server->getMetadata();
 
-        $this->assertEquals('x86_64', $metadata['architecture']);
-        $this->assertEquals('True', $metadata['auto_disk_config']);
-        $this->assertEquals('nokernel', $metadata['kernel_id']);
-        $this->assertEquals('nokernel', $metadata['ramdisk_id']);
+        self::assertEquals('x86_64', $metadata['architecture']);
+        self::assertEquals('True', $metadata['auto_disk_config']);
+        self::assertEquals('nokernel', $metadata['kernel_id']);
+        self::assertEquals('nokernel', $metadata['ramdisk_id']);
     }
 
     public function test_it_sets_metadata()
@@ -361,7 +361,7 @@ class ServerTest extends TestCase
 
         $this->server->resetMetadata($metadata);
 
-        $this->assertEquals('1', $this->server->metadata['foo']);
+        self::assertEquals('1', $this->server->metadata['foo']);
     }
 
     public function test_it_updates_metadata()
@@ -374,8 +374,8 @@ class ServerTest extends TestCase
 
         $this->server->mergeMetadata($metadata);
 
-        $this->assertEquals('1', $this->server->metadata['foo']);
-        $this->assertEquals('2', $this->server->metadata['bar']);
+        self::assertEquals('1', $this->server->metadata['foo']);
+        self::assertEquals('2', $this->server->metadata['bar']);
     }
 
     public function test_it_retrieves_a_metadata_item()
@@ -385,14 +385,14 @@ class ServerTest extends TestCase
 
         $value = $this->server->getMetadataItem('fooKey');
 
-        $this->assertEquals('bar', $value);
+        self::assertEquals('bar', $value);
     }
 
     public function test_it_deletes_a_metadata_item()
     {
         $this->setupMock('DELETE', 'servers/serverId/metadata/fooKey', null, [], new Response(204));
 
-        $this->assertNull($this->server->deleteMetadataItem('fooKey'));
+        self::assertNull($this->server->deleteMetadataItem('fooKey'));
     }
 
     public function test_it_lists_security_groups()
@@ -401,7 +401,7 @@ class ServerTest extends TestCase
 
         $securityGroups = iterator_to_array($this->server->listSecurityGroups());
 
-        $this->assertInstanceOf(SecurityGroup::class, $securityGroups[0]);
+        self::assertInstanceOf(SecurityGroup::class, $securityGroups[0]);
     }
 
     public function test_it_lists_volume_attachments()
@@ -410,7 +410,7 @@ class ServerTest extends TestCase
 
         $volumeAttachments = iterator_to_array($this->server->listVolumeAttachments());
 
-        $this->assertInstanceOf(VolumeAttachment::class, $volumeAttachments[0]);
+        self::assertInstanceOf(VolumeAttachment::class, $volumeAttachments[0]);
     }
 
     public function test_it_remove_security_group()
@@ -454,11 +454,11 @@ class ServerTest extends TestCase
         $this->setupMock('POST', 'servers/serverId/os-volume_attachments', $expectedJson, [], 'server-volume-attach-post');
 
         $volumeAttachment = $this->server->attachVolume($volumeId);
-        $this->assertInstanceOf(VolumeAttachment::class, $volumeAttachment);
-        $this->assertEquals('serverId', $volumeAttachment->serverId);
-        $this->assertEquals('a26887c6-c47b-4654-abb5-dfadf7d3f803', $volumeAttachment->id);
-        $this->assertEquals($volumeId, $volumeAttachment->volumeId);
-        $this->assertEquals('/dev/vdd', $volumeAttachment->device);
+        self::assertInstanceOf(VolumeAttachment::class, $volumeAttachment);
+        self::assertEquals('serverId', $volumeAttachment->serverId);
+        self::assertEquals('a26887c6-c47b-4654-abb5-dfadf7d3f803', $volumeAttachment->id);
+        self::assertEquals($volumeId, $volumeAttachment->volumeId);
+        self::assertEquals('/dev/vdd', $volumeAttachment->device);
     }
 
     public function test_it_detaches_volume()
@@ -476,14 +476,14 @@ class ServerTest extends TestCase
 
         $interfaceAttachments = iterator_to_array($this->server->listInterfaceAttachments());
 
-        $this->assertEquals('ce531f90-199f-48c0-816c-13e38010b442', $interfaceAttachments[0]->portId);
-        $this->assertEquals('ACTIVE', $interfaceAttachments[0]->portState);
-        $this->assertEquals('3cb9bc59-5699-4588-a4b1-b87f96708bc6', $interfaceAttachments[0]->netId);
-        $this->assertEquals('fa:16:3e:4c:2c:30', $interfaceAttachments[0]->macAddr);
-        $this->assertEquals('192.168.1.3', $interfaceAttachments[0]->fixedIps[0]['ip_address']);
-        $this->assertEquals('f8a6e8f8-c2ec-497c-9f23-da9616de54ef', $interfaceAttachments[0]->fixedIps[0]['subnet_id']);
+        self::assertEquals('ce531f90-199f-48c0-816c-13e38010b442', $interfaceAttachments[0]->portId);
+        self::assertEquals('ACTIVE', $interfaceAttachments[0]->portState);
+        self::assertEquals('3cb9bc59-5699-4588-a4b1-b87f96708bc6', $interfaceAttachments[0]->netId);
+        self::assertEquals('fa:16:3e:4c:2c:30', $interfaceAttachments[0]->macAddr);
+        self::assertEquals('192.168.1.3', $interfaceAttachments[0]->fixedIps[0]['ip_address']);
+        self::assertEquals('f8a6e8f8-c2ec-497c-9f23-da9616de54ef', $interfaceAttachments[0]->fixedIps[0]['subnet_id']);
 
-        $this->assertInstanceOf(InterfaceAttachment::class, $interfaceAttachments[0]);
+        self::assertInstanceOf(InterfaceAttachment::class, $interfaceAttachments[0]);
     }
 
     /** @test */
@@ -495,12 +495,12 @@ class ServerTest extends TestCase
 
         $interfaceAttachment = $this->server->getInterfaceAttachment($portId);
 
-        $this->assertEquals('ce531f90-199f-48c0-816c-13e38010b442', $interfaceAttachment->portId);
-        $this->assertEquals('ACTIVE', $interfaceAttachment->portState);
-        $this->assertEquals('3cb9bc59-5699-4588-a4b1-b87f96708bc6', $interfaceAttachment->netId);
-        $this->assertEquals('fa:16:3e:4c:2c:30', $interfaceAttachment->macAddr);
-        $this->assertEquals('192.168.1.3', $interfaceAttachment->fixedIps[0]['ip_address']);
-        $this->assertEquals('f8a6e8f8-c2ec-497c-9f23-da9616de54ef', $interfaceAttachment->fixedIps[0]['subnet_id']);
+        self::assertEquals('ce531f90-199f-48c0-816c-13e38010b442', $interfaceAttachment->portId);
+        self::assertEquals('ACTIVE', $interfaceAttachment->portState);
+        self::assertEquals('3cb9bc59-5699-4588-a4b1-b87f96708bc6', $interfaceAttachment->netId);
+        self::assertEquals('fa:16:3e:4c:2c:30', $interfaceAttachment->macAddr);
+        self::assertEquals('192.168.1.3', $interfaceAttachment->fixedIps[0]['ip_address']);
+        self::assertEquals('f8a6e8f8-c2ec-497c-9f23-da9616de54ef', $interfaceAttachment->fixedIps[0]['subnet_id']);
     }
 
     /** @test */
@@ -516,8 +516,8 @@ class ServerTest extends TestCase
 
         $interfaceAttachment = $this->server->createInterfaceAttachment(['networkId' => $networkId]);
 
-        $this->assertEquals('ACTIVE', $interfaceAttachment->portState);
-        $this->assertEquals('10.0.0.1', $interfaceAttachment->fixedIps[0]['ip_address']);
+        self::assertEquals('ACTIVE', $interfaceAttachment->portState);
+        self::assertEquals('10.0.0.1', $interfaceAttachment->fixedIps[0]['ip_address']);
     }
 
     public function test_it_detaches_interfaces()

--- a/tests/unit/Compute/v2/Models/ServerTest.php
+++ b/tests/unit/Compute/v2/Models/ServerTest.php
@@ -16,7 +16,7 @@ class ServerTest extends TestCase
     /** @var Server */
     private $server;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -62,12 +62,10 @@ class ServerTest extends TestCase
         $this->assertInstanceOf(Server::class, $this->server->create($opts));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage imageId or blockDeviceMapping.uuid must be set.
-     */
     public function test_it_requires_image_id_or_volume_id_to_create_servers()
     {
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('imageId or blockDeviceMapping.uuid must be set.');
         $this->server->create([
             'name' => 'some-server-name',
             'flavorId' => 'apple'
@@ -125,11 +123,9 @@ class ServerTest extends TestCase
         $this->assertNull($this->server->reboot());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function test_an_exception_is_thrown_when_rebooting_with_an_invalid_type()
     {
+		$this->expectException(\Exception::class);
         $this->server->reboot('foo');
     }
 
@@ -327,7 +323,7 @@ class ServerTest extends TestCase
 
         $ips = $this->server->listAddresses();
 
-        $this->assertInternalType('array', $ips);
+        self::assertIsArray($ips);
         $this->assertCount(4, $ips['public']);
         $this->assertCount(2, $ips['private']);
     }
@@ -338,7 +334,7 @@ class ServerTest extends TestCase
 
         $ips = $this->server->listAddresses(['networkLabel' => 'foo']);
 
-        $this->assertInternalType('array', $ips);
+        self::assertIsArray($ips);
         $this->assertCount(4, $ips['public']);
         $this->assertCount(2, $ips['private']);
     }

--- a/tests/unit/Compute/v2/ServiceTest.php
+++ b/tests/unit/Compute/v2/ServiceTest.php
@@ -46,7 +46,7 @@ class ServiceTest extends TestCase
 
         $this->setupMock('POST', 'servers', $expectedJson, [], 'server-post');
 
-        $this->assertInstanceOf(Server::class, $this->service->createServer($opts));
+        self::assertInstanceOf(Server::class, $this->service->createServer($opts));
     }
 
     public function test_it_lists_servers()
@@ -57,7 +57,7 @@ class ServiceTest extends TestCase
             ->willReturn($this->getFixture('servers-get'));
 
         foreach ($this->service->listServers(false, ['limit' => 5]) as $server) {
-            $this->assertInstanceOf(Server::class, $server);
+            self::assertInstanceOf(Server::class, $server);
         }
     }
 
@@ -67,8 +67,8 @@ class ServiceTest extends TestCase
             'id' => 'serverId'
         ]);
 
-        $this->assertInstanceOf(Server::class, $server);
-        $this->assertEquals('serverId', $server->id);
+        self::assertInstanceOf(Server::class, $server);
+        self::assertEquals('serverId', $server->id);
     }
 
     public function test_it_lists_flavors()
@@ -82,10 +82,10 @@ class ServiceTest extends TestCase
 
         foreach ($this->service->listFlavors(['limit' => 5]) as $flavor) {
             ++$count;
-            $this->assertInstanceOf(Flavor::class, $flavor);
+            self::assertInstanceOf(Flavor::class, $flavor);
         }
 
-        $this->assertEquals(5, $count);
+        self::assertEquals(5, $count);
     }
 
     public function test_it_gets_a_flavor()
@@ -94,8 +94,8 @@ class ServiceTest extends TestCase
             'id' => 'flavorId'
         ]);
 
-        $this->assertInstanceOf(Flavor::class, $flavor);
-        $this->assertEquals('flavorId', $flavor->id);
+        self::assertInstanceOf(Flavor::class, $flavor);
+        self::assertEquals('flavorId', $flavor->id);
     }
 
     public function test_it_lists_images()
@@ -106,7 +106,7 @@ class ServiceTest extends TestCase
             ->willReturn($this->getFixture('images-get'));
 
         foreach ($this->service->listImages(['limit' => 5]) as $image) {
-            $this->assertInstanceOf(Image::class, $image);
+            self::assertInstanceOf(Image::class, $image);
         }
     }
 
@@ -116,8 +116,8 @@ class ServiceTest extends TestCase
             'id' => 'imageId'
         ]);
 
-        $this->assertInstanceOf(Image::class, $image);
-        $this->assertEquals('imageId', $image->id);
+        self::assertInstanceOf(Image::class, $image);
+        self::assertEquals('imageId', $image->id);
     }
 
     public function test_it_lists_keypairs()
@@ -128,7 +128,7 @@ class ServiceTest extends TestCase
             ->willReturn($this->getFixture('keypairs-get'));
 
         foreach ($this->service->listKeypairs() as $keypair) {
-            $this->assertInstanceOf(Keypair::class, $keypair);
+            self::assertInstanceOf(Keypair::class, $keypair);
         }
     }
 
@@ -141,7 +141,7 @@ class ServiceTest extends TestCase
 
         $hypervisorStats = $this->service->getHypervisorStatistics();
 
-        $this->assertInstanceOf(HypervisorStatistic::class, $hypervisorStats);
+        self::assertInstanceOf(HypervisorStatistic::class, $hypervisorStats);
     }
 
     public function test_it_lists_hypervisors()
@@ -152,7 +152,7 @@ class ServiceTest extends TestCase
             ->willReturn($this->getFixture('hypervisors-get'));
 
         foreach ($this->service->listHypervisors(false) as $hypervisor) {
-            $this->assertInstanceOf(Hypervisor::class, $hypervisor);
+            self::assertInstanceOf(Hypervisor::class, $hypervisor);
         }
     }
 
@@ -166,7 +166,7 @@ class ServiceTest extends TestCase
         $hypervisor = $this->service->getHypervisor(['id' => 1234]);
         $hypervisor->retrieve();
 
-        $this->assertInstanceOf(Hypervisor::class, $hypervisor);
+        self::assertInstanceOf(Hypervisor::class, $hypervisor);
     }
 
     public function test_it_lists_hosts()
@@ -177,7 +177,7 @@ class ServiceTest extends TestCase
             ->willReturn($this->getFixture('hosts-get'));
 
         foreach ($this->service->listHosts(['limit' => 5]) as $host) {
-            $this->assertInstanceOf(Host::class, $host);
+            self::assertInstanceOf(Host::class, $host);
         }
     }
 
@@ -191,7 +191,7 @@ class ServiceTest extends TestCase
         $host = $this->service->getHost(['name' => 'b6e4adbc193d428ea923899d07fb001e']);
         $host->retrieve();
 
-        $this->assertInstanceOf(Host::class, $host);
+        self::assertInstanceOf(Host::class, $host);
     }
 
     public function test_it_lists_availability_zones()
@@ -202,7 +202,7 @@ class ServiceTest extends TestCase
             ->willReturn($this->getFixture('availability-zones-get'));
 
         foreach ($this->service->listAvailabilityZones(['limit' => 5]) as $zone) {
-            $this->assertInstanceOf(AvailabilityZone::class, $zone);
+            self::assertInstanceOf(AvailabilityZone::class, $zone);
         }
     }
 }

--- a/tests/unit/Compute/v2/ServiceTest.php
+++ b/tests/unit/Compute/v2/ServiceTest.php
@@ -21,7 +21,7 @@ class ServiceTest extends TestCase
     /** @var Service */
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Identity/v2/Models/CatalogTest.php
+++ b/tests/unit/Identity/v2/Models/CatalogTest.php
@@ -10,18 +10,16 @@ class CatalogTest extends TestCase
 {
     private $catalog;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->catalog = new Catalog($this->client->reveal(), new Api());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function test_it_throws_exception_when_no_endpoint_url_is_found()
     {
+		$this->expectException(\RuntimeException::class);
         $this->catalog->getServiceUrl('foo', 'bar', 'baz');
     }
 }

--- a/tests/unit/Identity/v2/Models/EndpointTest.php
+++ b/tests/unit/Identity/v2/Models/EndpointTest.php
@@ -23,7 +23,7 @@ class EndpointTest extends TestCase
 
         $this->endpoint->populateFromArray(['internalURL' => $url]);
 
-        $this->assertEquals($url, $this->endpoint->getUrl('internalURL'));
+        self::assertEquals($url, $this->endpoint->getUrl('internalURL'));
     }
 
     public function test_it_supports_admin_urls()
@@ -32,6 +32,6 @@ class EndpointTest extends TestCase
 
         $this->endpoint->populateFromArray(['adminURL' => $url]);
 
-        $this->assertEquals($url, $this->endpoint->getUrl('adminURL'));
+        self::assertEquals($url, $this->endpoint->getUrl('adminURL'));
     }
 }

--- a/tests/unit/Identity/v2/Models/EndpointTest.php
+++ b/tests/unit/Identity/v2/Models/EndpointTest.php
@@ -10,7 +10,7 @@ class EndpointTest extends TestCase
 {
     private $endpoint;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Identity/v2/Models/EntryTest.php
+++ b/tests/unit/Identity/v2/Models/EntryTest.php
@@ -19,6 +19,6 @@ class EntryTest extends TestCase
 
     public function test_null_is_returned_when_no_endpoints_are_found()
     {
-        $this->assertEmpty($this->entry->getEndpointUrl('foo', 'bar'));
+        self::assertEmpty($this->entry->getEndpointUrl('foo', 'bar'));
     }
 }

--- a/tests/unit/Identity/v2/Models/EntryTest.php
+++ b/tests/unit/Identity/v2/Models/EntryTest.php
@@ -10,7 +10,7 @@ class EntryTest extends TestCase
 {
     private $entry;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Identity/v2/Models/TokenTest.php
+++ b/tests/unit/Identity/v2/Models/TokenTest.php
@@ -9,11 +9,11 @@ use OpenStack\Test\TestCase;
 class TokenTest extends TestCase
 {
     private $token;
-    
-    public function setUp()
+
+    public function setUp(): void
     {
         parent::setUp();
-        
+
         $this->token = new Token($this->client->reveal(), new Api());
     }
 

--- a/tests/unit/Identity/v2/Models/TokenTest.php
+++ b/tests/unit/Identity/v2/Models/TokenTest.php
@@ -20,7 +20,7 @@ class TokenTest extends TestCase
     public function test_getting_id()
     {
         $this->token->id = 'foo';
-        $this->assertEquals('foo', $this->token->getId());
+        self::assertEquals('foo', $this->token->getId());
     }
 
     public function test_expiration_is_false_for_active_tokens()
@@ -30,7 +30,7 @@ class TokenTest extends TestCase
             'expires'   => date('c', strtotime('tomorrow'))
         ]);
 
-        $this->assertFalse($this->token->hasExpired());
+        self::assertFalse($this->token->hasExpired());
     }
 
     public function test_expiration_is_true_for_old_tokens()
@@ -40,6 +40,6 @@ class TokenTest extends TestCase
             'expires'   => date('c', strtotime('last thursday'))
         ]);
 
-        $this->assertTrue($this->token->hasExpired());
+        self::assertTrue($this->token->hasExpired());
     }
 }

--- a/tests/unit/Identity/v2/ServiceTest.php
+++ b/tests/unit/Identity/v2/ServiceTest.php
@@ -44,7 +44,7 @@ class ServiceTest extends TestCase
 
         list($token, $baseUrl) = $this->service->authenticate($options);
 
-        $this->assertInstanceOf(Token::class, $token);
+        self::assertInstanceOf(Token::class, $token);
         self::assertIsString($baseUrl);
     }
 
@@ -66,6 +66,6 @@ class ServiceTest extends TestCase
 
         $this->setupMock('POST', 'tokens', $expectedJson, [], 'token-post');
 
-        $this->assertInstanceOf(Token::class, $this->service->generateToken($options));
+        self::assertInstanceOf(Token::class, $this->service->generateToken($options));
     }
 }

--- a/tests/unit/Identity/v2/ServiceTest.php
+++ b/tests/unit/Identity/v2/ServiceTest.php
@@ -11,7 +11,7 @@ class ServiceTest extends TestCase
 {
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -45,9 +45,9 @@ class ServiceTest extends TestCase
         list($token, $baseUrl) = $this->service->authenticate($options);
 
         $this->assertInstanceOf(Token::class, $token);
-        $this->assertInternalType('string', $baseUrl);
+        self::assertIsString($baseUrl);
     }
-    
+
     public function test_it_generates_tokens()
     {
         $options = [

--- a/tests/unit/Identity/v3/Models/CatalogTest.php
+++ b/tests/unit/Identity/v3/Models/CatalogTest.php
@@ -24,7 +24,7 @@ class CatalogTest extends TestCase
     public function test_it_throws_if_no_services_set()
     {
 		$this->expectException(\RuntimeException::class);
-        $this->assertFalse($this->catalog->getServiceUrl('', '', '', ''));
+        self::assertFalse($this->catalog->getServiceUrl('', '', '', ''));
     }
 
     public function test_it_returns_service_url()
@@ -36,7 +36,7 @@ class CatalogTest extends TestCase
 
         $this->catalog->services = [$service->reveal()];
 
-        $this->assertEquals($url, $this->catalog->getServiceUrl('foo', 'bar', 'baz', ''));
+        self::assertEquals($url, $this->catalog->getServiceUrl('foo', 'bar', 'baz', ''));
     }
 
     public function test_it_throws_if_no_url_found()
@@ -47,6 +47,6 @@ class CatalogTest extends TestCase
 
         $this->catalog->services = [$service->reveal()];
 
-        $this->assertFalse($this->catalog->getServiceUrl('', '', '', ''));
+        self::assertFalse($this->catalog->getServiceUrl('', '', '', ''));
     }
 }

--- a/tests/unit/Identity/v3/Models/CatalogTest.php
+++ b/tests/unit/Identity/v3/Models/CatalogTest.php
@@ -12,7 +12,7 @@ class CatalogTest extends TestCase
 {
     private $catalog;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rootFixturesDir = dirname(__DIR__);
 
@@ -21,11 +21,9 @@ class CatalogTest extends TestCase
         $this->catalog = new Catalog($this->client->reveal(), new Api());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function test_it_throws_if_no_services_set()
     {
+		$this->expectException(\RuntimeException::class);
         $this->assertFalse($this->catalog->getServiceUrl('', '', '', ''));
     }
 
@@ -41,13 +39,11 @@ class CatalogTest extends TestCase
         $this->assertEquals($url, $this->catalog->getServiceUrl('foo', 'bar', 'baz', ''));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function test_it_throws_if_no_url_found()
     {
         $service = $this->prophesize(Service::class);
         $service->getUrl(Argument::any(), Argument::cetera())->shouldBeCalled()->willReturn(false);
+		$this->expectException(\RuntimeException::class);
 
         $this->catalog->services = [$service->reveal()];
 

--- a/tests/unit/Identity/v3/Models/CredentialTest.php
+++ b/tests/unit/Identity/v3/Models/CredentialTest.php
@@ -11,7 +11,7 @@ class CredentialTest extends TestCase
 {
     private $credential;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rootFixturesDir = dirname(__DIR__);
 

--- a/tests/unit/Identity/v3/Models/DomainTest.php
+++ b/tests/unit/Identity/v3/Models/DomainTest.php
@@ -63,13 +63,13 @@ class DomainTest extends TestCase
     public function test_it_grants_user_role()
     {
         $this->setupMock('PUT', 'domains/DOMAIN_ID/users/USER_ID/roles/ROLE_ID', null, [], new Response(204));
-        $this->assertNull($this->domain->grantUserRole(['userId' => 'USER_ID', 'roleId' => 'ROLE_ID']));
+        self::assertNull($this->domain->grantUserRole(['userId' => 'USER_ID', 'roleId' => 'ROLE_ID']));
     }
 
     public function test_it_checks_user_role()
     {
         $this->setupMock('HEAD', 'domains/DOMAIN_ID/users/USER_ID/roles/ROLE_ID', null, [], new Response(200));
-        $this->assertTrue($this->domain->checkUserRole(['userId' => 'USER_ID', 'roleId' => 'ROLE_ID']));
+        self::assertTrue($this->domain->checkUserRole(['userId' => 'USER_ID', 'roleId' => 'ROLE_ID']));
     }
 
     public function test_it_checks_nonexistent_user_role()
@@ -79,7 +79,7 @@ class DomainTest extends TestCase
             ->shouldBeCalled()
             ->willThrow(new BadResponseError());
 
-        $this->assertFalse($this->domain->checkUserRole(['userId' => 'USER_ID', 'roleId' => 'ROLE_ID']));
+        self::assertFalse($this->domain->checkUserRole(['userId' => 'USER_ID', 'roleId' => 'ROLE_ID']));
     }
 
     public function test_it_revokes_user_role()
@@ -97,13 +97,13 @@ class DomainTest extends TestCase
     public function test_it_grants_group_role()
     {
         $this->setupMock('PUT', 'domains/DOMAIN_ID/groups/GROUP_ID/roles/ROLE_ID', null, [], new Response(204));
-        $this->assertNull($this->domain->grantGroupRole(['groupId' => 'GROUP_ID', 'roleId' => 'ROLE_ID']));
+        self::assertNull($this->domain->grantGroupRole(['groupId' => 'GROUP_ID', 'roleId' => 'ROLE_ID']));
     }
 
     public function test_it_checks_group_role()
     {
         $this->setupMock('HEAD', 'domains/DOMAIN_ID/groups/GROUP_ID/roles/ROLE_ID', null, [], new Response(200));
-        $this->assertTrue($this->domain->checkGroupRole(['groupId' => 'GROUP_ID', 'roleId' => 'ROLE_ID']));
+        self::assertTrue($this->domain->checkGroupRole(['groupId' => 'GROUP_ID', 'roleId' => 'ROLE_ID']));
     }
 
     public function test_it_checks_nonexistent_group_role()
@@ -113,7 +113,7 @@ class DomainTest extends TestCase
             ->shouldBeCalled()
             ->willThrow(new BadResponseError());
 
-        $this->assertFalse($this->domain->checkGroupRole(['groupId' => 'GROUP_ID', 'roleId' => 'ROLE_ID']));
+        self::assertFalse($this->domain->checkGroupRole(['groupId' => 'GROUP_ID', 'roleId' => 'ROLE_ID']));
     }
 
     public function test_it_revokes_group_role()

--- a/tests/unit/Identity/v3/Models/DomainTest.php
+++ b/tests/unit/Identity/v3/Models/DomainTest.php
@@ -13,7 +13,7 @@ class DomainTest extends TestCase
 {
     private $domain;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rootFixturesDir = dirname(__DIR__);
 

--- a/tests/unit/Identity/v3/Models/EndpointTest.php
+++ b/tests/unit/Identity/v3/Models/EndpointTest.php
@@ -13,7 +13,7 @@ class EndpointTest extends TestCase
     private $endpoint;
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rootFixturesDir = dirname(__DIR__);
 

--- a/tests/unit/Identity/v3/Models/EndpointTest.php
+++ b/tests/unit/Identity/v3/Models/EndpointTest.php
@@ -44,7 +44,7 @@ class EndpointTest extends TestCase
         /** @var $endpoint \OpenStack\Identity\v3\Models\Endpoint */
         $endpoint = $this->service->createEndpoint($userOptions);
 
-        $this->assertInstanceOf(Endpoint::class, $endpoint);
+        self::assertInstanceOf(Endpoint::class, $endpoint);
     }
 
     public function test_it_updates_endpoint()

--- a/tests/unit/Identity/v3/Models/GroupTest.php
+++ b/tests/unit/Identity/v3/Models/GroupTest.php
@@ -13,7 +13,7 @@ class GroupTest extends TestCase
 {
     private $group;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rootFixturesDir = dirname(__DIR__);
         parent::setUp();

--- a/tests/unit/Identity/v3/Models/GroupTest.php
+++ b/tests/unit/Identity/v3/Models/GroupTest.php
@@ -48,7 +48,7 @@ class GroupTest extends TestCase
         /** @var $group \OpenStack\Identity\v3\Models\Group */
         $group = $this->group->create($userOptions);
 
-        $this->assertInstanceOf(Group::class, $group);
+        self::assertInstanceOf(Group::class, $group);
     }
 
     public function test_it_updates_group()
@@ -104,6 +104,6 @@ class GroupTest extends TestCase
             ->shouldBeCalled()
             ->willThrow(new BadResponseError());
 
-        $this->assertFalse($this->group->checkMembership(['userId' => 'USER_ID']));
+        self::assertFalse($this->group->checkMembership(['userId' => 'USER_ID']));
     }
 }

--- a/tests/unit/Identity/v3/Models/PolicyTest.php
+++ b/tests/unit/Identity/v3/Models/PolicyTest.php
@@ -42,8 +42,8 @@ class PolicyTest extends TestCase
         /** @var $policy \OpenStack\Identity\v3\Models\Policy */
         $policy = $this->policy->create($userOptions);
 
-        $this->assertInstanceOf(Policy::class, $policy);
-        $this->assertEquals('--policy-id--', $policy->id);
+        self::assertInstanceOf(Policy::class, $policy);
+        self::assertEquals('--policy-id--', $policy->id);
     }
 
     public function test_it_retrieves()

--- a/tests/unit/Identity/v3/Models/PolicyTest.php
+++ b/tests/unit/Identity/v3/Models/PolicyTest.php
@@ -11,7 +11,7 @@ class PolicyTest extends TestCase
 {
     private $policy;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rootFixturesDir = dirname(__DIR__);
 

--- a/tests/unit/Identity/v3/Models/ProjectTest.php
+++ b/tests/unit/Identity/v3/Models/ProjectTest.php
@@ -13,7 +13,7 @@ class ProjectTest extends TestCase
 {
     private $project;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rootFixturesDir = dirname(__DIR__);
 

--- a/tests/unit/Identity/v3/Models/ProjectTest.php
+++ b/tests/unit/Identity/v3/Models/ProjectTest.php
@@ -75,7 +75,7 @@ class ProjectTest extends TestCase
     {
         $this->setupMock('HEAD', 'projects/PROJECT_ID/users/USER_ID/roles/ROLE_ID', null, [], new Response(200));
 
-        $this->assertTrue($this->project->checkUserRole(['userId' => 'USER_ID', 'roleId' => 'ROLE_ID']));
+        self::assertTrue($this->project->checkUserRole(['userId' => 'USER_ID', 'roleId' => 'ROLE_ID']));
     }
 
     public function test_it_checks_nonexistent_user_role()
@@ -85,7 +85,7 @@ class ProjectTest extends TestCase
             ->shouldBeCalled()
             ->willThrow(new BadResponseError());
 
-        $this->assertFalse($this->project->checkUserRole(['userId' => 'USER_ID', 'roleId' => 'ROLE_ID']));
+        self::assertFalse($this->project->checkUserRole(['userId' => 'USER_ID', 'roleId' => 'ROLE_ID']));
     }
 
     public function test_it_revokes_user_role()
@@ -112,7 +112,7 @@ class ProjectTest extends TestCase
     {
         $this->setupMock('HEAD', 'projects/PROJECT_ID/groups/GROUP_ID/roles/ROLE_ID', null, [], new Response(200));
 
-        $this->assertTrue($this->project->checkGroupRole(['groupId' => 'GROUP_ID', 'roleId' => 'ROLE_ID']));
+        self::assertTrue($this->project->checkGroupRole(['groupId' => 'GROUP_ID', 'roleId' => 'ROLE_ID']));
     }
 
     public function test_it_checks_nonexistent_group_role()
@@ -122,7 +122,7 @@ class ProjectTest extends TestCase
             ->shouldBeCalled()
             ->willThrow(new BadResponseError());
 
-        $this->assertFalse($this->project->checkGroupRole(['groupId' => 'GROUP_ID', 'roleId' => 'ROLE_ID']));
+        self::assertFalse($this->project->checkGroupRole(['groupId' => 'GROUP_ID', 'roleId' => 'ROLE_ID']));
     }
 
     public function test_it_revokes_group_role()

--- a/tests/unit/Identity/v3/Models/RoleTest.php
+++ b/tests/unit/Identity/v3/Models/RoleTest.php
@@ -11,7 +11,7 @@ class RoleTest extends TestCase
 {
     private $role;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rootFixturesDir = dirname(__DIR__);
 

--- a/tests/unit/Identity/v3/Models/ServiceTest.php
+++ b/tests/unit/Identity/v3/Models/ServiceTest.php
@@ -12,7 +12,7 @@ class ServiceTest extends TestCase
 {
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rootFixturesDir = dirname(__DIR__);
 

--- a/tests/unit/Identity/v3/Models/ServiceTest.php
+++ b/tests/unit/Identity/v3/Models/ServiceTest.php
@@ -47,7 +47,7 @@ class ServiceTest extends TestCase
 
     public function test_it_returns_false_if_name_and_type_does_not_match()
     {
-        $this->assertFalse($this->service->getUrl('foo', 'bar', '', ''));
+        self::assertFalse($this->service->getUrl('foo', 'bar', '', ''));
     }
 
     public function test_it_retrieves_url_if_name_type_and_region_match()
@@ -61,7 +61,7 @@ class ServiceTest extends TestCase
         $this->service->type = 'bar';
         $this->service->endpoints = [$endpoint];
 
-        $this->assertNotNull($this->service->getUrl('foo', 'bar', 'baz', 'internal'));
-        $this->assertFalse($this->service->getUrl('foo', 'bar', 'bat', ''));
+        self::assertNotNull($this->service->getUrl('foo', 'bar', 'baz', 'internal'));
+        self::assertFalse($this->service->getUrl('foo', 'bar', 'bat', ''));
     }
 }

--- a/tests/unit/Identity/v3/Models/TokenTest.php
+++ b/tests/unit/Identity/v3/Models/TokenTest.php
@@ -22,16 +22,16 @@ class TokenTest extends TestCase
 
     public function test_getting_id()
     {
-        $this->assertEquals('TOKEN_ID', $this->token->getId());
+        self::assertEquals('TOKEN_ID', $this->token->getId());
     }
 
     public function test_it_returns_false_if_expired()
     {
         $this->token->expires = new \DateTimeImmutable('yesterday');
-        $this->assertTrue($this->token->hasExpired());
+        self::assertTrue($this->token->hasExpired());
 
         $this->token->expires = new \DateTimeImmutable('tomorrow');
-        $this->assertFalse($this->token->hasExpired());
+        self::assertFalse($this->token->hasExpired());
     }
 
     public function test_it_throws_error_when_username_is_not_qualified_by_domain_id()

--- a/tests/unit/Identity/v3/Models/TokenTest.php
+++ b/tests/unit/Identity/v3/Models/TokenTest.php
@@ -10,7 +10,7 @@ class TokenTest extends TestCase
 {
     private $token;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rootFixturesDir = dirname(__DIR__);
 
@@ -34,19 +34,15 @@ class TokenTest extends TestCase
         $this->assertFalse($this->token->hasExpired());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function test_it_throws_error_when_username_is_not_qualified_by_domain_id()
     {
+		$this->expectException(\InvalidArgumentException::class);
         $this->token->create(['user' => ['name' => 'foo']]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function test_it_throws_error_when_neither_user_creds_or_token_id_is_provided()
     {
+		$this->expectException(\InvalidArgumentException::class);
         $this->token->create([]);
     }
 }

--- a/tests/unit/Identity/v3/Models/UserTest.php
+++ b/tests/unit/Identity/v3/Models/UserTest.php
@@ -11,7 +11,7 @@ class UserTest extends TestCase
 {
     private $user;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rootFixturesDir = dirname(__DIR__);
 

--- a/tests/unit/Identity/v3/ServiceTest.php
+++ b/tests/unit/Identity/v3/ServiceTest.php
@@ -62,8 +62,8 @@ class ServiceTest extends TestCase
 
         list($token, $url) = $this->service->authenticate($userOptions);
 
-        $this->assertInstanceOf(Models\Token::class, $token);
-        $this->assertEquals('http://example.org:8080/v1/AUTH_e00abf65afca49609eedd163c515cf10', $url);
+        self::assertInstanceOf(Models\Token::class, $token);
+        self::assertEquals('http://example.org:8080/v1/AUTH_e00abf65afca49609eedd163c515cf10', $url);
     }
 
     public function test_it_authenticates_using_cache_token()
@@ -136,8 +136,8 @@ class ServiceTest extends TestCase
 
         list($token, $url) = $this->service->authenticate($userOptions);
 
-        $this->assertInstanceOf(Models\Token::class, $token);
-        $this->assertEquals('http://example.org:8080/v1/AUTH_e00abf65afca49609eedd163c515cf10', $url);
+        self::assertInstanceOf(Models\Token::class, $token);
+        self::assertEquals('http://example.org:8080/v1/AUTH_e00abf65afca49609eedd163c515cf10', $url);
     }
 
     public function test_it_authenticates_and_throws_exception_when_authenticate_with_expired_cached_token()
@@ -256,10 +256,10 @@ class ServiceTest extends TestCase
         $token = $this->service->getToken('tokenId');
         $token->retrieve();
 
-        $this->assertInstanceOf(Models\Token::class, $token);
-        $this->assertEquals(new \DateTimeImmutable('2013-02-27T18:30:59.999999Z'), $token->expires);
-        $this->assertEquals(new \DateTimeImmutable('2013-02-27T16:30:59.999999Z'), $token->issued);
-        $this->assertEquals(['password'], $token->methods);
+        self::assertInstanceOf(Models\Token::class, $token);
+        self::assertEquals(new \DateTimeImmutable('2013-02-27T18:30:59.999999Z'), $token->expires);
+        self::assertEquals(new \DateTimeImmutable('2013-02-27T16:30:59.999999Z'), $token->issued);
+        self::assertEquals(['password'], $token->methods);
 
         $user = $this->service->model(Models\User::class, [
             "domain" => [
@@ -275,14 +275,14 @@ class ServiceTest extends TestCase
             ],
             "name"   => "Joe"
         ]);
-        $this->assertEquals($user, $token->user);
+        self::assertEquals($user, $token->user);
     }
 
     public function test_false_is_returned_when_token_validation_returns_204()
     {
         $this->setupMock('HEAD', 'auth/tokens', [], ['X-Subject-Token' => 'tokenId'], new Response(204));
 
-        $this->assertTrue($this->service->validateToken('tokenId'));
+        self::assertTrue($this->service->validateToken('tokenId'));
     }
 
     public function test_true_is_returned_when_token_validation_returns_error()
@@ -292,14 +292,14 @@ class ServiceTest extends TestCase
             ->shouldBeCalled()
             ->willThrow(new BadResponseError());
 
-        $this->assertFalse($this->service->validateToken('tokenId'));
+        self::assertFalse($this->service->validateToken('tokenId'));
     }
 
     public function test_it_revokes_token()
     {
         $this->setupMock('DELETE', 'auth/tokens', [], ['X-Subject-Token' => 'tokenId'], new Response(204));
 
-        $this->assertNull($this->service->revokeToken('tokenId'));
+        self::assertNull($this->service->revokeToken('tokenId'));
     }
 
     public function test_it_creates_service()
@@ -310,10 +310,10 @@ class ServiceTest extends TestCase
 
         $service = $this->service->createService($userOptions);
 
-        $this->assertInstanceOf(Models\Service::class, $service);
-        $this->assertEquals('serviceId', $service->id);
-        $this->assertEquals('foo', $service->name);
-        $this->assertEquals('bar', $service->type);
+        self::assertInstanceOf(Models\Service::class, $service);
+        self::assertEquals('serviceId', $service->id);
+        self::assertEquals('foo', $service->name);
+        self::assertEquals('bar', $service->type);
     }
 
     public function test_it_lists_services()
@@ -346,13 +346,13 @@ class ServiceTest extends TestCase
         /** @var $endpoint \OpenStack\Identity\v3\Models\Endpoint */
         $endpoint = $this->service->createEndpoint($userOptions);
 
-        $this->assertInstanceOf(Models\Endpoint::class, $endpoint);
+        self::assertInstanceOf(Models\Endpoint::class, $endpoint);
 
-        $this->assertEquals($userOptions['interface'], $endpoint->interface);
-        $this->assertEquals($userOptions['name'], $endpoint->name);
-        $this->assertEquals($userOptions['region'], $endpoint->region);
-        $this->assertEquals($userOptions['url'], $endpoint->url);
-        $this->assertEquals($userOptions['serviceId'], $endpoint->serviceId);
+        self::assertEquals($userOptions['interface'], $endpoint->interface);
+        self::assertEquals($userOptions['name'], $endpoint->name);
+        self::assertEquals($userOptions['region'], $endpoint->region);
+        self::assertEquals($userOptions['url'], $endpoint->url);
+        self::assertEquals($userOptions['serviceId'], $endpoint->serviceId);
     }
 
     public function test_it_creates_domain()
@@ -368,12 +368,12 @@ class ServiceTest extends TestCase
         /** @var $endpoint \OpenStack\Identity\v3\Models\Domain */
         $domain = $this->service->createDomain($userOptions);
 
-        $this->assertInstanceOf(Models\Domain::class, $domain);
+        self::assertInstanceOf(Models\Domain::class, $domain);
 
-        $this->assertEquals('12345', $domain->id);
-        $this->assertTrue($domain->enabled);
-        $this->assertEquals('foo', $domain->name);
-        $this->assertEquals('bar', $domain->description);
+        self::assertEquals('12345', $domain->id);
+        self::assertTrue($domain->enabled);
+        self::assertEquals('foo', $domain->name);
+        self::assertEquals('bar', $domain->description);
     }
 
     public function test_it_lists_domains()
@@ -399,11 +399,11 @@ class ServiceTest extends TestCase
         /** @var $endpoint \OpenStack\Identity\v3\Models\Project */
         $project = $this->service->createProject($userOptions);
 
-        $this->assertInstanceOf(Models\Project::class, $project);
+        self::assertInstanceOf(Models\Project::class, $project);
 
-        $this->assertEquals('456789', $project->id);
-        $this->assertTrue($project->enabled);
-        $this->assertEquals('myNewProject', $project->name);
+        self::assertEquals('456789', $project->id);
+        self::assertTrue($project->enabled);
+        self::assertEquals('myNewProject', $project->name);
     }
 
     public function test_it_lists_projects()
@@ -412,16 +412,16 @@ class ServiceTest extends TestCase
 
         $projects = $this->service->listProjects();
 
-        $this->assertInstanceOf('\Generator', $projects);
+        self::assertInstanceOf('\Generator', $projects);
 
         $count = 0;
 
         foreach ($projects as $project) {
-            $this->assertInstanceOf(Models\Project::class, $project);
+            self::assertInstanceOf(Models\Project::class, $project);
             ++$count;
         }
 
-        $this->assertEquals(2, $count);
+        self::assertEquals(2, $count);
     }
 
     public function test_it_gets_project()
@@ -451,15 +451,15 @@ class ServiceTest extends TestCase
         /** @var $endpoint \OpenStack\Identity\v3\Models\User */
         $user = $this->service->createUser($userOptions);
 
-        $this->assertInstanceOf(Models\User::class, $user);
+        self::assertInstanceOf(Models\User::class, $user);
 
-        $this->assertEquals('263fd9', $user->defaultProjectId);
-        $this->assertEquals("Jim Doe's user", $user->description);
-        $this->assertEquals("1789d1", $user->domainId);
-        $this->assertEquals("jdoe@example.com", $user->email);
-        $this->assertTrue($user->enabled);
-        $this->assertEquals('ff4e51', $user->id);
-        $this->assertEquals('jdoe', $user->name);
+        self::assertEquals('263fd9', $user->defaultProjectId);
+        self::assertEquals("Jim Doe's user", $user->description);
+        self::assertEquals("1789d1", $user->domainId);
+        self::assertEquals("jdoe@example.com", $user->email);
+        self::assertTrue($user->enabled);
+        self::assertEquals('ff4e51', $user->id);
+        self::assertEquals('jdoe', $user->name);
     }
 
     public function test_it_lists_users()
@@ -484,12 +484,12 @@ class ServiceTest extends TestCase
         /** @var $endpoint \OpenStack\Identity\v3\Models\Group */
         $group = $this->service->createGroup($userOptions);
 
-        $this->assertInstanceOf(Models\Group::class, $group);
+        self::assertInstanceOf(Models\Group::class, $group);
 
-        $this->assertEquals($userOptions['description'], $group->description);
-        $this->assertEquals($userOptions['name'], $group->name);
-        $this->assertEquals('id', $group->id);
-        $this->assertEquals('domain_id', $group->domainId);
+        self::assertEquals($userOptions['description'], $group->description);
+        self::assertEquals($userOptions['name'], $group->name);
+        self::assertEquals('id', $group->id);
+        self::assertEquals('domain_id', $group->domainId);
     }
 
     public function test_it_lists_groups()
@@ -523,12 +523,12 @@ class ServiceTest extends TestCase
         /** @var $endpoint \OpenStack\Identity\v3\Models\Credential */
         $cred = $this->service->createCredential($userOptions);
 
-        $this->assertInstanceOf(Models\Credential::class, $cred);
+        self::assertInstanceOf(Models\Credential::class, $cred);
 
-        $this->assertEquals($userOptions['blob'], $cred->blob);
-        $this->assertEquals($userOptions['projectId'], $cred->projectId);
-        $this->assertEquals('id', $cred->id);
-        $this->assertEquals($userOptions['type'], $cred->type);
+        self::assertEquals($userOptions['blob'], $cred->blob);
+        self::assertEquals($userOptions['projectId'], $cred->projectId);
+        self::assertEquals('id', $cred->id);
+        self::assertEquals($userOptions['type'], $cred->type);
     }
 
     public function test_it_lists_credentials()
@@ -550,9 +550,9 @@ class ServiceTest extends TestCase
         /** @var $endpoint \OpenStack\Identity\v3\Models\Role */
         $role = $this->service->createRole($userOptions);
 
-        $this->assertInstanceOf(Models\Role::class, $role);
+        self::assertInstanceOf(Models\Role::class, $role);
 
-        $this->assertEquals($userOptions['name'], $role->name);
+        self::assertEquals($userOptions['name'], $role->name);
     }
 
     public function test_it_lists_roles()
@@ -587,7 +587,7 @@ class ServiceTest extends TestCase
         /** @var $endpoint \OpenStack\Identity\v3\Models\Policy */
         $policy = $this->service->createPolicy($userOptions);
 
-        $this->assertInstanceOf(Models\Policy::class, $policy);
+        self::assertInstanceOf(Models\Policy::class, $policy);
     }
 
     public function test_it_lists_policies()
@@ -632,7 +632,7 @@ class ServiceTest extends TestCase
         $this->setupMock('POST', 'auth/tokens', ['auth' => $expectedJson], [], 'token');
 
         $token = $this->service->generateToken($userOptions);
-        $this->assertInstanceOf(Models\Token::class, $token);
+        self::assertInstanceOf(Models\Token::class, $token);
     }
 
     public function test_it_generates_token_with_token_id()
@@ -657,7 +657,7 @@ class ServiceTest extends TestCase
         $this->setupMock('POST', 'auth/tokens', ['auth' => $expectedJson], [], 'token');
 
         $token = $this->service->generateToken($userOptions);
-        $this->assertInstanceOf(Models\Token::class, $token);
+        self::assertInstanceOf(Models\Token::class, $token);
     }
 
     public function test_it_generates_token_from_cache()
@@ -673,8 +673,8 @@ class ServiceTest extends TestCase
 
         $token = $this->service->generateTokenFromCache($cache);
 
-        $this->assertInstanceOf(Models\Token::class, $token);
-        $this->assertEquals('some-token-id', $token->id);
+        self::assertInstanceOf(Models\Token::class, $token);
+        self::assertEquals('some-token-id', $token->id);
     }
 
     public function test_it_lists_endpoints()

--- a/tests/unit/Identity/v3/ServiceTest.php
+++ b/tests/unit/Identity/v3/ServiceTest.php
@@ -17,7 +17,7 @@ class ServiceTest extends TestCase
     /** @var Service */
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -140,11 +140,6 @@ class ServiceTest extends TestCase
         $this->assertEquals('http://example.org:8080/v1/AUTH_e00abf65afca49609eedd163c515cf10', $url);
     }
 
-
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Cached token has expired
-     */
     public function test_it_authenticates_and_throws_exception_when_authenticate_with_expired_cached_token()
     {
         $cachedToken = [
@@ -212,14 +207,13 @@ class ServiceTest extends TestCase
             'region'      => 'RegionOne',
             'cachedToken' => $cachedToken
         ];
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('Cached token has expired');
 
         $this->service->authenticate($userOptions);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function test_it_throws_exception_if_no_endpoint_found()
+   public function test_it_throws_exception_if_no_endpoint_found()
     {
         $expectedJson = [
             "identity" => [
@@ -238,6 +232,7 @@ class ServiceTest extends TestCase
         ];
 
         $this->setupMock('POST', 'auth/tokens', ['auth' => $expectedJson], [], 'token');
+		$this->expectException(\RuntimeException::class);
 
         $this->service->authenticate([
             'catalogName' => 'foo',

--- a/tests/unit/Images/v2/JsonPatchTest.php
+++ b/tests/unit/Images/v2/JsonPatchTest.php
@@ -24,7 +24,7 @@ class JsonPatchTest extends TestCase
             ['op' => 'add', 'path' => '/foo', 'value' => 'val'],
         ];
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function test_it_removes_elements_from_arrays()
@@ -37,6 +37,6 @@ class JsonPatchTest extends TestCase
             ['op' => 'remove', 'path' => '/foo/2'],
         ];
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }

--- a/tests/unit/Images/v2/JsonPatchTest.php
+++ b/tests/unit/Images/v2/JsonPatchTest.php
@@ -9,7 +9,7 @@ class JsonPatchTest extends TestCase
 {
     private $jsonPatch;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->jsonPatch = new JsonPatch();
     }

--- a/tests/unit/Images/v2/Models/ImageTest.php
+++ b/tests/unit/Images/v2/Models/ImageTest.php
@@ -17,7 +17,7 @@ class ImageTest extends TestCase
 
     private $path;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -87,15 +87,13 @@ class ImageTest extends TestCase
         $this->image->update($opts);
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_it_throws_exception_if_user_input_does_not_match_schema()
     {
         $this->client->getConfig('base_uri')->shouldBeCalled()->willReturn(new Uri);
 
         $this->setupMock('GET', $this->path, null, [], 'GET_image');
         $this->setupMock('GET', 'v2/schemas/image', null, [], 'GET_image_schema');
+        $this->expectException(\Exception::class);
 
         $this->image->update([
             'minDisk' => 'foo',

--- a/tests/unit/Images/v2/Models/ImageTest.php
+++ b/tests/unit/Images/v2/Models/ImageTest.php
@@ -36,22 +36,22 @@ class ImageTest extends TestCase
 
         $this->image->retrieve();
 
-        $this->assertEquals("active", $this->image->status);
-        $this->assertEquals("foo", $this->image->name);
-        $this->assertEquals([], $this->image->tags);
-        $this->assertEquals("ami", $this->image->containerFormat);
-        $this->assertEquals(new \DateTimeImmutable("2015-11-12T14:26:08+0000"), $this->image->createdAt);
-        $this->assertEquals("ami", $this->image->diskFormat);
-        $this->assertEquals(new \DateTimeImmutable("2015-12-01T12:25:42+0000"), $this->image->updatedAt);
-        $this->assertEquals("public", $this->image->visibility);
-        $this->assertEquals(20, $this->image->minDisk);
-        $this->assertFalse($this->image->protected);
-        $this->assertEquals("386f0425-3ee8-4688-b73f-272328fe4c71", $this->image->id);
-        $this->assertEquals("061d01418b94d4743a98ee26d941e87c", $this->image->checksum);
-        $this->assertEquals("057aad9fa85b4e29b23e7888000446ef", $this->image->ownerId);
-        $this->assertEquals(983040, $this->image->size);
-        $this->assertEquals(0, $this->image->minRam);
-        $this->assertNull($this->image->virtualSize);
+        self::assertEquals("active", $this->image->status);
+        self::assertEquals("foo", $this->image->name);
+        self::assertEquals([], $this->image->tags);
+        self::assertEquals("ami", $this->image->containerFormat);
+        self::assertEquals(new \DateTimeImmutable("2015-11-12T14:26:08+0000"), $this->image->createdAt);
+        self::assertEquals("ami", $this->image->diskFormat);
+        self::assertEquals(new \DateTimeImmutable("2015-12-01T12:25:42+0000"), $this->image->updatedAt);
+        self::assertEquals("public", $this->image->visibility);
+        self::assertEquals(20, $this->image->minDisk);
+        self::assertFalse($this->image->protected);
+        self::assertEquals("386f0425-3ee8-4688-b73f-272328fe4c71", $this->image->id);
+        self::assertEquals("061d01418b94d4743a98ee26d941e87c", $this->image->checksum);
+        self::assertEquals("057aad9fa85b4e29b23e7888000446ef", $this->image->ownerId);
+        self::assertEquals(983040, $this->image->size);
+        self::assertEquals(0, $this->image->minRam);
+        self::assertNull($this->image->virtualSize);
     }
 
     public function test_it_updates()
@@ -139,7 +139,7 @@ class ImageTest extends TestCase
 
         $this->setupMock('GET', $this->path . '/file', null, [], $response);
 
-        $this->assertInstanceOf(Stream::class, $this->image->downloadData());
+        self::assertInstanceOf(Stream::class, $this->image->downloadData());
     }
 
     public function test_it_creates_member()
@@ -150,7 +150,7 @@ class ImageTest extends TestCase
         $this->setupMock('POST', $this->path . '/members', $expectedJson, [], 'POST_members');
 
         $member = $this->image->addMember('8989447062e04a818baf9e073fd04fa7');
-        $this->assertInstanceOf(Member::class, $member);
+        self::assertInstanceOf(Member::class, $member);
     }
 
     public function test_it_lists_members()
@@ -164,14 +164,14 @@ class ImageTest extends TestCase
 
         foreach ($this->image->listMembers() as $member) {
             ++$count;
-            $this->assertInstanceOf(Member::class, $member);
+            self::assertInstanceOf(Member::class, $member);
         }
 
-        $this->assertEquals(2, $count);
+        self::assertEquals(2, $count);
     }
 
     public function test_it_gets_members()
     {
-        $this->assertInstanceOf(Member::class, $this->image->getMember('id'));
+        self::assertInstanceOf(Member::class, $this->image->getMember('id'));
     }
 }

--- a/tests/unit/Images/v2/Models/MemberTest.php
+++ b/tests/unit/Images/v2/Models/MemberTest.php
@@ -11,7 +11,7 @@ class MemberTest extends TestCase
 {
     private $member;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Images/v2/ServiceTest.php
+++ b/tests/unit/Images/v2/ServiceTest.php
@@ -12,7 +12,7 @@ class ServiceTest extends TestCase
 {
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Images/v2/ServiceTest.php
+++ b/tests/unit/Images/v2/ServiceTest.php
@@ -69,12 +69,12 @@ class ServiceTest extends TestCase
             ->willReturn($this->getFixture('GET_images'));
 
         foreach ($this->service->listImages(['limit' => 5]) as $image) {
-            $this->assertInstanceOf(Image::class, $image);
+            self::assertInstanceOf(Image::class, $image);
         }
     }
 
     public function test_it_gets_image()
     {
-        $this->assertInstanceOf(Image::class, $this->service->getImage('id'));
+        self::assertInstanceOf(Image::class, $this->service->getImage('id'));
     }
 }

--- a/tests/unit/Metric/v1/Gnocchi/Models/MetricTest.php
+++ b/tests/unit/Metric/v1/Gnocchi/Models/MetricTest.php
@@ -11,7 +11,7 @@ class MetricTest extends TestCase
     /** @var Metric */
     private $metric;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Metric/v1/Gnocchi/Models/MetricTest.php
+++ b/tests/unit/Metric/v1/Gnocchi/Models/MetricTest.php
@@ -26,7 +26,7 @@ class MetricTest extends TestCase
         $this->setupMock('GET', 'v1/metric/000b7bf8-0271-46dd-90aa-cfe89026a55a', null, [], 'metric-get');
         $this->metric->retrieve();
 
-        $this->assertEquals('000b7bf8-0271-46dd-90aa-cfe89026a55a', $this->metric->id);
-        $this->assertEquals('storage.objects.outgoing.bytes', $this->metric->name);
+        self::assertEquals('000b7bf8-0271-46dd-90aa-cfe89026a55a', $this->metric->id);
+        self::assertEquals('storage.objects.outgoing.bytes', $this->metric->name);
     }
 }

--- a/tests/unit/Metric/v1/Gnocchi/Models/ResourceTest.php
+++ b/tests/unit/Metric/v1/Gnocchi/Models/ResourceTest.php
@@ -27,11 +27,11 @@ class ResourceTest extends TestCase
     {
         $this->setupMock('GET', 'v1/resource/generic/1111', null, [], 'resource-get');
         $this->resource->retrieve();
-        $this->assertEquals('fake-project-id', $this->resource->projectId);
-        $this->assertEquals('fake-created-by-user-id', $this->resource->createdByUserId);
-        $this->assertEquals('fake-type', $this->resource->type);
+        self::assertEquals('fake-project-id', $this->resource->projectId);
+        self::assertEquals('fake-created-by-user-id', $this->resource->createdByUserId);
+        self::assertEquals('fake-type', $this->resource->type);
         self::assertIsArray($this->resource->metrics);
-        $this->assertEquals(8, count($this->resource->metrics));
+        self::assertEquals(8, count($this->resource->metrics));
     }
 
 
@@ -42,9 +42,9 @@ class ResourceTest extends TestCase
         /** @var Metric $metric */
         $metric = $this->resource->getMetric('storage.objects.outgoing.bytes');
 
-        $this->assertInstanceOf(Metric::class, $metric);
-        $this->assertEquals($metric->name, 'storage.objects.outgoing.bytes');
-        $this->assertEquals($metric->id, '000b7bf8-0271-46dd-90aa-cfe89026a55a');
+        self::assertInstanceOf(Metric::class, $metric);
+        self::assertEquals($metric->name, 'storage.objects.outgoing.bytes');
+        self::assertEquals($metric->id, '000b7bf8-0271-46dd-90aa-cfe89026a55a');
     }
 
     public function test_it_gets_metric_measures()
@@ -53,8 +53,8 @@ class ResourceTest extends TestCase
         $measures = $this->resource->getMetricMeasures(['metric' => 'storage.objects.outgoing.bytes']);
 
         self::assertIsArray($measures);
-        $this->assertEquals(7, count($measures));
-        $this->assertEquals('2017-05-16T00:00:00+00:00', $measures[0][0]);
+        self::assertEquals(7, count($measures));
+        self::assertEquals('2017-05-16T00:00:00+00:00', $measures[0][0]);
     }
 
     public function test_it_lists_resource_metrics()
@@ -63,7 +63,7 @@ class ResourceTest extends TestCase
 
         $result = iterator_to_array($this->resource->listResourceMetrics());
 
-        $this->assertEquals(23, count($result));
-        $this->assertContainsOnlyInstancesOf(Metric::class, $result);
+        self::assertEquals(23, count($result));
+        self::assertContainsOnlyInstancesOf(Metric::class, $result);
     }
 }

--- a/tests/unit/Metric/v1/Gnocchi/Models/ResourceTest.php
+++ b/tests/unit/Metric/v1/Gnocchi/Models/ResourceTest.php
@@ -12,7 +12,7 @@ class ResourceTest extends TestCase
     /** @var Resource */
     private $resource;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -30,7 +30,7 @@ class ResourceTest extends TestCase
         $this->assertEquals('fake-project-id', $this->resource->projectId);
         $this->assertEquals('fake-created-by-user-id', $this->resource->createdByUserId);
         $this->assertEquals('fake-type', $this->resource->type);
-        $this->assertInternalType('array', $this->resource->metrics);
+        self::assertIsArray($this->resource->metrics);
         $this->assertEquals(8, count($this->resource->metrics));
     }
 
@@ -52,7 +52,7 @@ class ResourceTest extends TestCase
         $this->setupMock('GET', sprintf('v1/resource/generic/1111/metric/storage.objects.outgoing.bytes/measures'), [], [], 'resource-metric-measures-get');
         $measures = $this->resource->getMetricMeasures(['metric' => 'storage.objects.outgoing.bytes']);
 
-        $this->assertInternalType('array', $measures);
+        self::assertIsArray($measures);
         $this->assertEquals(7, count($measures));
         $this->assertEquals('2017-05-16T00:00:00+00:00', $measures[0][0]);
     }

--- a/tests/unit/Metric/v1/Gnocchi/ServiceTest.php
+++ b/tests/unit/Metric/v1/Gnocchi/ServiceTest.php
@@ -30,8 +30,8 @@ class ServiceTest extends TestCase
 
         $result = iterator_to_array($this->service->listResourceTypes());
 
-        $this->assertEquals(15, count($result));
-        $this->assertContainsOnlyInstancesOf(ResourceType::class, $result);
+        self::assertEquals(15, count($result));
+        self::assertContainsOnlyInstancesOf(ResourceType::class, $result);
     }
 
     public function test_it_lists_resources()
@@ -43,16 +43,16 @@ class ServiceTest extends TestCase
 
         $result = iterator_to_array($this->service->listResources(['limit' => 3]));
 
-        $this->assertEquals(3, count($result));
-        $this->assertContainsOnlyInstancesOf(Resource::class, $result);
+        self::assertEquals(3, count($result));
+        self::assertContainsOnlyInstancesOf(Resource::class, $result);
     }
 
     public function test_it_get_resource()
     {
         $resource = $this->service->getResource(['id' => '1']);
 
-        $this->assertEquals('1', $resource->id);
-        $this->assertInstanceOf(Resource::class, $resource);
+        self::assertEquals('1', $resource->id);
+        self::assertInstanceOf(Resource::class, $resource);
     }
 
     public function test_it_search_resources()
@@ -62,7 +62,7 @@ class ServiceTest extends TestCase
             ->shouldBeCalled()
             ->willReturn($this->getFixture('resources-get'));
         $result = $this->service->searchResources(['type' => 'generic']);
-        $this->assertContainsOnlyInstancesOf(Resource::class, $result);
+        self::assertContainsOnlyInstancesOf(Resource::class, $result);
     }
 
     public function test_it_search_resources_with_custom_type()
@@ -74,7 +74,7 @@ class ServiceTest extends TestCase
 
         $result = $this->service->searchResources(['type' => 'instance']);
 
-        $this->assertContainsOnlyInstancesOf(Resource::class, $result);
+        self::assertContainsOnlyInstancesOf(Resource::class, $result);
     }
 
     public function test_it_lists_metrics()
@@ -86,11 +86,11 @@ class ServiceTest extends TestCase
 
         $result = $this->service->listMetrics(['limit' => 5]);
 
-        $this->assertContainsOnlyInstancesOf(Metric::class, $result);
+        self::assertContainsOnlyInstancesOf(Metric::class, $result);
     }
 
     public function test_it_get_metric()
     {
-        $this->assertInstanceOf(Metric::class, $this->service->getMetric('metric-id'));
+        self::assertInstanceOf(Metric::class, $this->service->getMetric('metric-id'));
     }
 }

--- a/tests/unit/Metric/v1/Gnocchi/ServiceTest.php
+++ b/tests/unit/Metric/v1/Gnocchi/ServiceTest.php
@@ -14,7 +14,7 @@ class ServiceTest extends TestCase
     /** @var Service */
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->rootFixturesDir = __DIR__;

--- a/tests/unit/Networking/v2/Extensions/Layer3/Models/FloatingIpTest.php
+++ b/tests/unit/Networking/v2/Extensions/Layer3/Models/FloatingIpTest.php
@@ -49,32 +49,32 @@ class FloatingIpTest extends TestCase
 
         $this->floatingIp->retrieve();
 
-        $this->assertEquals(
+        self::assertEquals(
             '376da547-b977-4cfe-9cba-275c80debf57',
                             $this->floatingIp->floatingNetworkId
         );
-        $this->assertEquals(
+        self::assertEquals(
             'd23abc8d-2991-4a55-ba98-2aaea84cc72f',
                             $this->floatingIp->routerId
         );
-        $this->assertEquals(
+        self::assertEquals(
             '10.0.0.3',
                             $this->floatingIp->fixedIpAddress
         );
-        $this->assertEquals(
+        self::assertEquals(
             '172.24.4.228',
                             $this->floatingIp->floatingIpAddress
         );
-        $this->assertEquals(
+        self::assertEquals(
             '4969c491a3c74ee4af974e6d800c62de',
                             $this->floatingIp->tenantId
         );
-        $this->assertEquals('ACTIVE', $this->floatingIp->status);
-        $this->assertEquals(
+        self::assertEquals('ACTIVE', $this->floatingIp->status);
+        self::assertEquals(
             'ce705c24-c1ef-408a-bda3-7bbd946164ab',
                             $this->floatingIp->portId
         );
-        $this->assertEquals(
+        self::assertEquals(
             '2f245a7b-796b-4f26-9cf9-9e82d248fda7',
                             $this->floatingIp->id
         );

--- a/tests/unit/Networking/v2/Extensions/Layer3/Models/FloatingIpTest.php
+++ b/tests/unit/Networking/v2/Extensions/Layer3/Models/FloatingIpTest.php
@@ -12,7 +12,7 @@ class FloatingIpTest extends TestCase
     /** @var FloatingIp */
     private $floatingIp;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Networking/v2/Extensions/Layer3/Models/RouterTest.php
+++ b/tests/unit/Networking/v2/Extensions/Layer3/Models/RouterTest.php
@@ -14,7 +14,7 @@ class RouterTest extends TestCase
     /** @var Router */
     private $router;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Networking/v2/Extensions/Layer3/Models/RouterTest.php
+++ b/tests/unit/Networking/v2/Extensions/Layer3/Models/RouterTest.php
@@ -70,8 +70,8 @@ class RouterTest extends TestCase
 
         $this->router->retrieve();
 
-        $this->assertEquals('f8a44de0-fc8e-45df-93c7-f79bf3b01c95', $this->router->id);
-        $this->assertCount(2, $this->router->externalGatewayInfo->fixedIps);
+        self::assertEquals('f8a44de0-fc8e-45df-93c7-f79bf3b01c95', $this->router->id);
+        self::assertCount(2, $this->router->externalGatewayInfo->fixedIps);
     }
 
     public function test_it_adds_interface()

--- a/tests/unit/Networking/v2/Extensions/Layer3/ServiceTest.php
+++ b/tests/unit/Networking/v2/Extensions/Layer3/ServiceTest.php
@@ -14,7 +14,7 @@ class ServiceTest extends TestCase
     /** @var Service */
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Networking/v2/Extensions/Layer3/ServiceTest.php
+++ b/tests/unit/Networking/v2/Extensions/Layer3/ServiceTest.php
@@ -32,19 +32,19 @@ class ServiceTest extends TestCase
 
         foreach ($this->service->listFloatingIps() as $ip) {
             /** @var $ip FloatingIp */
-            $this->assertInstanceOf(FloatingIp::class, $ip);
+            self::assertInstanceOf(FloatingIp::class, $ip);
 
-            $this->assertNotNull($ip->tenantId);
-            $this->assertNotNull($ip->floatingNetworkId);
-            $this->assertNotNull($ip->floatingIpAddress);
-            $this->assertNotNull($ip->id);
-            $this->assertNotNull($ip->status);
+            self::assertNotNull($ip->tenantId);
+            self::assertNotNull($ip->floatingNetworkId);
+            self::assertNotNull($ip->floatingIpAddress);
+            self::assertNotNull($ip->id);
+            self::assertNotNull($ip->status);
         }
     }
 
     public function test_it_gets_floating_ip()
     {
-        $this->assertInstanceOf(FloatingIp::class, $this->service->getFloatingIp('id'));
+        self::assertInstanceOf(FloatingIp::class, $this->service->getFloatingIp('id'));
     }
 
     public function test_it_creates_floatingIp()
@@ -61,7 +61,7 @@ class ServiceTest extends TestCase
             "portId"            => "ce705c24-c1ef-408a-bda3-7bbd946164ab",
         ]);
 
-        $this->assertInstanceOf(FloatingIp::class, $ip);
+        self::assertInstanceOf(FloatingIp::class, $ip);
     }
 
     public function test_it_lists_routers()
@@ -73,19 +73,19 @@ class ServiceTest extends TestCase
 
         foreach ($this->service->listRouters() as $r) {
             /** @var $r Router */
-            $this->assertInstanceOf(Router::class, $r);
+            self::assertInstanceOf(Router::class, $r);
 
-            $this->assertNotNull($r->status);
-            $this->assertNotNull($r->name);
-            $this->assertNotNull($r->adminStateUp);
-            $this->assertNotNull($r->tenantId);
-            $this->assertNotNull($r->id);
+            self::assertNotNull($r->status);
+            self::assertNotNull($r->name);
+            self::assertNotNull($r->adminStateUp);
+            self::assertNotNull($r->tenantId);
+            self::assertNotNull($r->id);
         }
     }
 
     public function test_it_gets_router()
     {
-        $this->assertInstanceOf(Router::class, $this->service->getRouter('id'));
+        self::assertInstanceOf(Router::class, $this->service->getRouter('id'));
     }
 
     public function test_it_creates_router()
@@ -122,6 +122,6 @@ class ServiceTest extends TestCase
             ],
         ]);
 
-        $this->assertInstanceOf(Router::class, $r);
+        self::assertInstanceOf(Router::class, $r);
     }
 }

--- a/tests/unit/Networking/v2/Extensions/SecurityGroups/Models/SecurityGroupRuleTest.php
+++ b/tests/unit/Networking/v2/Extensions/SecurityGroups/Models/SecurityGroupRuleTest.php
@@ -12,7 +12,7 @@ class SecurityGroupRuleTest extends TestCase
     /** @var SecurityGroupRule */
     private $securityGroupRule;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Networking/v2/Extensions/SecurityGroups/Models/SecurityGroupTest.php
+++ b/tests/unit/Networking/v2/Extensions/SecurityGroups/Models/SecurityGroupTest.php
@@ -37,10 +37,10 @@ class SecurityGroupTest extends TestCase
 
         $this->securityGroup->retrieve();
 
-        $this->assertEquals('test_security_group', $this->securityGroup->name);
-        $this->assertEquals('test_security_group_description', $this->securityGroup->description);
-        $this->assertEquals(self::SECURITY_GROUP_ID, $this->securityGroup->id);
-        $this->assertEquals(2, count($this->securityGroup->securityGroupRules));
+        self::assertEquals('test_security_group', $this->securityGroup->name);
+        self::assertEquals('test_security_group_description', $this->securityGroup->description);
+        self::assertEquals(self::SECURITY_GROUP_ID, $this->securityGroup->id);
+        self::assertEquals(2, count($this->securityGroup->securityGroupRules));
     }
 
     public function test_it_updates()
@@ -66,6 +66,6 @@ class SecurityGroupTest extends TestCase
 
         $this->setupMock('POST', 'v2.0/security-groups', $expectedJson, [], 'SecurityGroup');
 
-        $this->assertInstanceOf(SecurityGroup::class, $this->securityGroup->create($opts));
+        self::assertInstanceOf(SecurityGroup::class, $this->securityGroup->create($opts));
     }
 }

--- a/tests/unit/Networking/v2/Extensions/SecurityGroups/Models/SecurityGroupTest.php
+++ b/tests/unit/Networking/v2/Extensions/SecurityGroups/Models/SecurityGroupTest.php
@@ -14,7 +14,7 @@ class SecurityGroupTest extends TestCase
 
     const SECURITY_GROUP_ID = '85cc3048-abc3-43cc-89b3-377341426ac5';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -42,7 +42,7 @@ class SecurityGroupTest extends TestCase
         $this->assertEquals(self::SECURITY_GROUP_ID, $this->securityGroup->id);
         $this->assertEquals(2, count($this->securityGroup->securityGroupRules));
     }
-    
+
     public function test_it_updates()
     {
         $this->setupMock('PUT', 'v2.0/security-groups/' . self::SECURITY_GROUP_ID, null, [], 'SecurityGroup');

--- a/tests/unit/Networking/v2/Extensions/SecurityGroups/ServiceTest.php
+++ b/tests/unit/Networking/v2/Extensions/SecurityGroups/ServiceTest.php
@@ -14,7 +14,7 @@ class ServiceTest extends TestCase
     /** @var Service */
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Networking/v2/Extensions/SecurityGroups/ServiceTest.php
+++ b/tests/unit/Networking/v2/Extensions/SecurityGroups/ServiceTest.php
@@ -32,12 +32,12 @@ class ServiceTest extends TestCase
 
         foreach ($this->service->listSecurityGroups() as $sg) {
             /** @var $sg SecurityGroup */
-            $this->assertInstanceOf(SecurityGroup::class, $sg);
+            self::assertInstanceOf(SecurityGroup::class, $sg);
 
-            $this->assertEquals('default', $sg->name);
-            $this->assertEquals('default', $sg->description);
-            $this->assertEquals('85cc3048-abc3-43cc-89b3-377341426ac5', $sg->id);
-            $this->assertCount(2, $sg->securityGroupRules);
+            self::assertEquals('default', $sg->name);
+            self::assertEquals('default', $sg->description);
+            self::assertEquals('85cc3048-abc3-43cc-89b3-377341426ac5', $sg->id);
+            self::assertCount(2, $sg->securityGroupRules);
         }
     }
 
@@ -53,12 +53,12 @@ class ServiceTest extends TestCase
         $this->setupMock('POST', 'v2.0/security-groups', $expectedJson, [], new Response(201));
 
         $n = $this->service->createSecurityGroup($options);
-        $this->assertInstanceOf(SecurityGroup::class, $n);
+        self::assertInstanceOf(SecurityGroup::class, $n);
     }
 
     public function test_it_gets_secgroup()
     {
-        $this->assertInstanceOf(SecurityGroup::class, $this->service->getSecurityGroup('id'));
+        self::assertInstanceOf(SecurityGroup::class, $this->service->getSecurityGroup('id'));
     }
 
     public function test_it_lists_secgrouprules()
@@ -70,13 +70,13 @@ class ServiceTest extends TestCase
 
         foreach ($this->service->listSecurityGroupRules() as $sgr) {
             /** @var $sgr SecurityGroupRule */
-            $this->assertInstanceOf(SecurityGroupRule::class, $sgr);
+            self::assertInstanceOf(SecurityGroupRule::class, $sgr);
 
-            $this->assertNotNull($sgr->direction);
-            $this->assertNotNull($sgr->ethertype);
-            $this->assertNotNull($sgr->id);
-            $this->assertNotNull($sgr->securityGroupId);
-            $this->assertNotNull($sgr->tenantId);
+            self::assertNotNull($sgr->direction);
+            self::assertNotNull($sgr->ethertype);
+            self::assertNotNull($sgr->id);
+            self::assertNotNull($sgr->securityGroupId);
+            self::assertNotNull($sgr->tenantId);
         }
     }
 
@@ -105,11 +105,11 @@ class ServiceTest extends TestCase
         $this->setupMock('POST', 'v2.0/security-group-rules', $expectedJson, [], new Response(201));
 
         $n = $this->service->createSecurityGroupRule($options);
-        $this->assertInstanceOf(SecurityGroupRule::class, $n);
+        self::assertInstanceOf(SecurityGroupRule::class, $n);
     }
 
     public function test_it_gets_secgrouprule()
     {
-        $this->assertInstanceOf(SecurityGroupRule::class, $this->service->getSecurityGroupRule('id'));
+        self::assertInstanceOf(SecurityGroupRule::class, $this->service->getSecurityGroupRule('id'));
     }
 }

--- a/tests/unit/Networking/v2/Models/LoadBalancerHealthMonitorTest.php
+++ b/tests/unit/Networking/v2/Models/LoadBalancerHealthMonitorTest.php
@@ -11,7 +11,7 @@ class LoadBalancerHealthMonitorTest extends TestCase
 {
     private $healthmonitor;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Networking/v2/Models/LoadBalancerHealthMonitorTest.php
+++ b/tests/unit/Networking/v2/Models/LoadBalancerHealthMonitorTest.php
@@ -49,7 +49,7 @@ class LoadBalancerHealthMonitorTest extends TestCase
 
         $this->setupMock('POST', 'v2.0/lbaas/healthmonitors', $expectedJson, [], 'loadbalancer-healthmonitor-post');
 
-        $this->assertInstanceOf(LoadBalancerHealthMonitor::class, $this->healthmonitor->create($opts));
+        self::assertInstanceOf(LoadBalancerHealthMonitor::class, $this->healthmonitor->create($opts));
     }
 
     public function test_it_updates()
@@ -84,12 +84,12 @@ class LoadBalancerHealthMonitorTest extends TestCase
 
         $this->healthmonitor->retrieve();
 
-        $this->assertEquals(1, $this->healthmonitor->delay);
-        $this->assertEquals(1, $this->healthmonitor->timeout);
-        $this->assertEquals('200', $this->healthmonitor->expectedCodes);
-        $this->assertEquals(5, $this->healthmonitor->maxRetries);
-        $this->assertEquals('GET', $this->healthmonitor->httpMethod);
-        $this->assertEquals('HTTP', $this->healthmonitor->type);
+        self::assertEquals(1, $this->healthmonitor->delay);
+        self::assertEquals(1, $this->healthmonitor->timeout);
+        self::assertEquals('200', $this->healthmonitor->expectedCodes);
+        self::assertEquals(5, $this->healthmonitor->maxRetries);
+        self::assertEquals('GET', $this->healthmonitor->httpMethod);
+        self::assertEquals('HTTP', $this->healthmonitor->type);
     }
 
     public function test_it_deletes()

--- a/tests/unit/Networking/v2/Models/LoadBalancerListenerTest.php
+++ b/tests/unit/Networking/v2/Models/LoadBalancerListenerTest.php
@@ -11,7 +11,7 @@ class LoadBalancerListenerTest extends TestCase
 {
     private $listener;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Networking/v2/Models/LoadBalancerListenerTest.php
+++ b/tests/unit/Networking/v2/Models/LoadBalancerListenerTest.php
@@ -45,7 +45,7 @@ class LoadBalancerListenerTest extends TestCase
 
         $this->setupMock('POST', 'v2.0/lbaas/listeners', $expectedJson, [], 'loadbalancer-listener-post');
 
-        $this->assertInstanceOf(LoadBalancerListener::class, $this->listener->create($opts));
+        self::assertInstanceOf(LoadBalancerListener::class, $this->listener->create($opts));
     }
 
     public function test_it_updates()
@@ -74,9 +74,9 @@ class LoadBalancerListenerTest extends TestCase
 
         $this->listener->retrieve();
 
-        $this->assertEquals('listenerId', $this->listener->id);
-        $this->assertEquals('listener1', $this->listener->name);
-        $this->assertEquals('simple listener', $this->listener->description);
+        self::assertEquals('listenerId', $this->listener->id);
+        self::assertEquals('listener1', $this->listener->name);
+        self::assertEquals('simple listener', $this->listener->description);
     }
 
     public function test_it_deletes()

--- a/tests/unit/Networking/v2/Models/LoadBalancerMemberTest.php
+++ b/tests/unit/Networking/v2/Models/LoadBalancerMemberTest.php
@@ -11,7 +11,7 @@ class LoadBalancerMemberTest extends TestCase
 {
     private $member;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Networking/v2/Models/LoadBalancerMemberTest.php
+++ b/tests/unit/Networking/v2/Models/LoadBalancerMemberTest.php
@@ -42,7 +42,7 @@ class LoadBalancerMemberTest extends TestCase
 
         $this->setupMock('POST', 'v2.0/lbaas/pools/poolId/members', $expectedJson, [], 'loadbalancer-member-post');
 
-        $this->assertInstanceOf(LoadBalancerMember::class, $this->member->create($opts));
+        self::assertInstanceOf(LoadBalancerMember::class, $this->member->create($opts));
     }
 
     public function test_it_updates()
@@ -67,9 +67,9 @@ class LoadBalancerMemberTest extends TestCase
 
         $this->member->retrieve();
 
-        $this->assertEquals('memberId', $this->member->id);
-        $this->assertEquals(1, $this->member->weight);
-        $this->assertEquals(true, $this->member->adminStateUp);
+        self::assertEquals('memberId', $this->member->id);
+        self::assertEquals(1, $this->member->weight);
+        self::assertEquals(true, $this->member->adminStateUp);
     }
 
     public function test_it_deletes()

--- a/tests/unit/Networking/v2/Models/LoadBalancerPoolTest.php
+++ b/tests/unit/Networking/v2/Models/LoadBalancerPoolTest.php
@@ -50,7 +50,7 @@ class LoadBalancerPoolTest extends TestCase
 
         $this->setupMock('POST', 'v2.0/lbaas/pools', $expectedJson, [], 'loadbalancer-pool-post');
 
-        $this->assertInstanceOf(LoadBalancerPool::class, $this->pool->create($opts));
+        self::assertInstanceOf(LoadBalancerPool::class, $this->pool->create($opts));
     }
 
     public function test_it_updates()
@@ -87,9 +87,9 @@ class LoadBalancerPoolTest extends TestCase
 
         $this->pool->retrieve();
 
-        $this->assertEquals('poolId', $this->pool->id);
-        $this->assertEquals('pool1', $this->pool->name);
-        $this->assertEquals('simple pool', $this->pool->description);
+        self::assertEquals('poolId', $this->pool->id);
+        self::assertEquals('pool1', $this->pool->name);
+        self::assertEquals('simple pool', $this->pool->description);
     }
 
     public function test_it_deletes()
@@ -119,14 +119,14 @@ class LoadBalancerPoolTest extends TestCase
 
         $this->setupMock('POST', 'v2.0/lbaas/pools/poolId/members', $expectedJson, [], 'loadbalancer-member-post');
 
-        $this->assertInstanceOf(LoadBalancerMember::class, $this->pool->addMember($opts));
+        self::assertInstanceOf(LoadBalancerMember::class, $this->pool->addMember($opts));
     }
 
     public function test_get_member()
     {
         $memberId = 'memberId';
 
-        $this->assertInstanceOf(LoadBalancerMember::class, $this->pool->getMember($memberId));
+        self::assertInstanceOf(LoadBalancerMember::class, $this->pool->getMember($memberId));
     }
 
     public function test_delete_member()
@@ -165,6 +165,6 @@ class LoadBalancerPoolTest extends TestCase
 
         $this->setupMock('POST', 'v2.0/lbaas/healthmonitors', $expectedJson, [], 'loadbalancer-healthmonitor-post');
 
-        $this->assertInstanceOf(LoadBalancerHealthMonitor::class, $this->pool->addHealthMonitor($opts));
+        self::assertInstanceOf(LoadBalancerHealthMonitor::class, $this->pool->addHealthMonitor($opts));
     }
 }

--- a/tests/unit/Networking/v2/Models/LoadBalancerPoolTest.php
+++ b/tests/unit/Networking/v2/Models/LoadBalancerPoolTest.php
@@ -13,7 +13,7 @@ class LoadBalancerPoolTest extends TestCase
 {
     private $pool;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Networking/v2/Models/LoadBalancerStatTest.php
+++ b/tests/unit/Networking/v2/Models/LoadBalancerStatTest.php
@@ -11,7 +11,7 @@ class LoadBalancerStatTest extends TestCase
 {
     private $stat;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Networking/v2/Models/LoadBalancerStatTest.php
+++ b/tests/unit/Networking/v2/Models/LoadBalancerStatTest.php
@@ -26,9 +26,9 @@ class LoadBalancerStatTest extends TestCase
         $this->setupMock('GET', 'v2.0/lbaas/loadbalancers/loadbalancerId/stats', null, [], 'loadbalancer-stats-get');
 
         $this->stat->retrieve();
-        $this->assertEquals('1234', $this->stat->bytesOut);
-        $this->assertEquals('4321', $this->stat->bytesIn);
-        $this->assertEquals(25, $this->stat->totalConnections);
-        $this->assertEquals(10, $this->stat->activeConnections);
+        self::assertEquals('1234', $this->stat->bytesOut);
+        self::assertEquals('4321', $this->stat->bytesIn);
+        self::assertEquals(25, $this->stat->totalConnections);
+        self::assertEquals(10, $this->stat->activeConnections);
     }
 }

--- a/tests/unit/Networking/v2/Models/LoadBalancerStatusTest.php
+++ b/tests/unit/Networking/v2/Models/LoadBalancerStatusTest.php
@@ -12,7 +12,7 @@ class LoadBalancerStatusTest extends TestCase
 {
     private $status;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -32,7 +32,7 @@ class LoadBalancerStatusTest extends TestCase
         $this->assertEquals('loadbalancerId', $this->status->id);
         $this->assertEquals('ONLINE', $this->status->operatingStatus);
         $this->assertEquals('ACTIVE', $this->status->provisioningStatus);
-        $this->assertInternalType('array', $this->status->listeners);
+        self::assertIsArray($this->status->listeners);
         $this->assertArrayHasKey(0, $this->status->listeners);
         $this->assertInstanceOf(LoadBalancerListener::class, $this->status->listeners[0]);
     }

--- a/tests/unit/Networking/v2/Models/LoadBalancerStatusTest.php
+++ b/tests/unit/Networking/v2/Models/LoadBalancerStatusTest.php
@@ -28,12 +28,12 @@ class LoadBalancerStatusTest extends TestCase
 
         $this->status->retrieve();
 
-        $this->assertEquals('loadbalancer1', $this->status->name);
-        $this->assertEquals('loadbalancerId', $this->status->id);
-        $this->assertEquals('ONLINE', $this->status->operatingStatus);
-        $this->assertEquals('ACTIVE', $this->status->provisioningStatus);
+        self::assertEquals('loadbalancer1', $this->status->name);
+        self::assertEquals('loadbalancerId', $this->status->id);
+        self::assertEquals('ONLINE', $this->status->operatingStatus);
+        self::assertEquals('ACTIVE', $this->status->provisioningStatus);
         self::assertIsArray($this->status->listeners);
-        $this->assertArrayHasKey(0, $this->status->listeners);
-        $this->assertInstanceOf(LoadBalancerListener::class, $this->status->listeners[0]);
+        self::assertArrayHasKey(0, $this->status->listeners);
+        self::assertInstanceOf(LoadBalancerListener::class, $this->status->listeners[0]);
     }
 }

--- a/tests/unit/Networking/v2/Models/LoadBalancerTest.php
+++ b/tests/unit/Networking/v2/Models/LoadBalancerTest.php
@@ -46,7 +46,7 @@ class LoadBalancerTest extends TestCase
 
         $this->setupMock('POST', 'v2.0/lbaas/loadbalancers', $expectedJson, [], 'loadbalancer-post');
 
-        $this->assertInstanceOf(LoadBalancer::class, $this->loadbalancer->create($opts));
+        self::assertInstanceOf(LoadBalancer::class, $this->loadbalancer->create($opts));
     }
 
     public function test_it_updates()
@@ -71,9 +71,9 @@ class LoadBalancerTest extends TestCase
 
         $this->loadbalancer->retrieve();
 
-        $this->assertEquals('loadbalancerId', $this->loadbalancer->id);
-        $this->assertEquals('loadbalancer1', $this->loadbalancer->name);
-        $this->assertEquals('simple lb', $this->loadbalancer->description);
+        self::assertEquals('loadbalancerId', $this->loadbalancer->id);
+        self::assertEquals('loadbalancer1', $this->loadbalancer->name);
+        self::assertEquals('simple lb', $this->loadbalancer->description);
     }
 
     public function test_it_deletes()
@@ -108,7 +108,7 @@ class LoadBalancerTest extends TestCase
 
         $this->setupMock('POST', 'v2.0/lbaas/listeners', $expectedJson, [], 'loadbalancer-listener-post');
 
-        $this->assertInstanceOf(LoadBalancerListener::class, $this->loadbalancer->addListener($opts));
+        self::assertInstanceOf(LoadBalancerListener::class, $this->loadbalancer->addListener($opts));
     }
 
     public function test_get_stats()
@@ -117,12 +117,12 @@ class LoadBalancerTest extends TestCase
 
         $stats = $this->loadbalancer->getStats();
 
-        $this->assertEquals('4321', $stats->bytesIn);
-        $this->assertEquals('1234', $stats->bytesOut);
-        $this->assertEquals(25, $stats->totalConnections);
-        $this->assertEquals(10, $stats->activeConnections);
-        $this->assertEquals($this->loadbalancer->id, $stats->loadbalancerId);
-        $this->assertInstanceOf(LoadBalancerStat::class, $stats);
+        self::assertEquals('4321', $stats->bytesIn);
+        self::assertEquals('1234', $stats->bytesOut);
+        self::assertEquals(25, $stats->totalConnections);
+        self::assertEquals(10, $stats->activeConnections);
+        self::assertEquals($this->loadbalancer->id, $stats->loadbalancerId);
+        self::assertInstanceOf(LoadBalancerStat::class, $stats);
     }
 
     public function test_get_statuses()
@@ -130,13 +130,13 @@ class LoadBalancerTest extends TestCase
         $this->setupMock('GET', 'v2.0/lbaas/loadbalancers/loadbalancerId/statuses', null, [], 'loadbalancer-statuses-get');
 
         $status = $this->loadbalancer->getStatuses();
-        $this->assertEquals('loadbalancer1', $status->name);
-        $this->assertEquals('loadbalancerId', $status->id);
-        $this->assertEquals('ONLINE', $status->operatingStatus);
-        $this->assertEquals('ACTIVE', $status->provisioningStatus);
+        self::assertEquals('loadbalancer1', $status->name);
+        self::assertEquals('loadbalancerId', $status->id);
+        self::assertEquals('ONLINE', $status->operatingStatus);
+        self::assertEquals('ACTIVE', $status->provisioningStatus);
         self::assertIsArray($status->listeners);
-        $this->assertArrayHasKey(0, $status->listeners);
-        $this->assertInstanceOf(LoadBalancerListener::class, $status->listeners[0]);
-        $this->assertInstanceOf(LoadBalancerStatus::class, $status);
+        self::assertArrayHasKey(0, $status->listeners);
+        self::assertInstanceOf(LoadBalancerListener::class, $status->listeners[0]);
+        self::assertInstanceOf(LoadBalancerStatus::class, $status);
     }
 }

--- a/tests/unit/Networking/v2/Models/LoadBalancerTest.php
+++ b/tests/unit/Networking/v2/Models/LoadBalancerTest.php
@@ -14,7 +14,7 @@ class LoadBalancerTest extends TestCase
 {
     private $loadbalancer;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -134,7 +134,7 @@ class LoadBalancerTest extends TestCase
         $this->assertEquals('loadbalancerId', $status->id);
         $this->assertEquals('ONLINE', $status->operatingStatus);
         $this->assertEquals('ACTIVE', $status->provisioningStatus);
-        $this->assertInternalType('array', $status->listeners);
+        self::assertIsArray($status->listeners);
         $this->assertArrayHasKey(0, $status->listeners);
         $this->assertInstanceOf(LoadBalancerListener::class, $status->listeners[0]);
         $this->assertInstanceOf(LoadBalancerStatus::class, $status);

--- a/tests/unit/Networking/v2/Models/NetworkTest.php
+++ b/tests/unit/Networking/v2/Models/NetworkTest.php
@@ -37,7 +37,7 @@ class NetworkTest extends TestCase
 
         $this->setupMock('POST', 'v2.0/networks', $expectedJson, [], 'network-post');
 
-        $this->assertInstanceOf(Network::class, $this->network->create($opts));
+        self::assertInstanceOf(Network::class, $this->network->create($opts));
     }
 
     public function test_it_bulk_creates()
@@ -75,7 +75,7 @@ class NetworkTest extends TestCase
         $networks = $this->network->bulkCreate($opts);
 
         self::assertIsArray($networks);
-        $this->assertCount(2, $networks);
+        self::assertCount(2, $networks);
     }
 
     public function test_it_updates()
@@ -102,9 +102,9 @@ class NetworkTest extends TestCase
 
         $this->network->retrieve();
 
-        $this->assertEquals('networkId', $this->network->id);
-        $this->assertEquals('fakenetwork', $this->network->name);
-        $this->assertEquals('ACTIVE', $this->network->status);
+        self::assertEquals('networkId', $this->network->id);
+        self::assertEquals('fakenetwork', $this->network->name);
+        self::assertEquals('ACTIVE', $this->network->status);
     }
 
     public function test_it_deletes()

--- a/tests/unit/Networking/v2/Models/NetworkTest.php
+++ b/tests/unit/Networking/v2/Models/NetworkTest.php
@@ -11,7 +11,7 @@ class NetworkTest extends TestCase
 {
     private $network;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -74,7 +74,7 @@ class NetworkTest extends TestCase
 
         $networks = $this->network->bulkCreate($opts);
 
-        $this->assertInternalType('array', $networks);
+        self::assertIsArray($networks);
         $this->assertCount(2, $networks);
     }
 

--- a/tests/unit/Networking/v2/Models/PortTest.php
+++ b/tests/unit/Networking/v2/Models/PortTest.php
@@ -15,7 +15,7 @@ class PortTest extends TestCase
     /** @var Port */
     private $port;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Networking/v2/Models/PortTest.php
+++ b/tests/unit/Networking/v2/Models/PortTest.php
@@ -52,15 +52,15 @@ class PortTest extends TestCase
         $this->setupMock('GET', 'v2.0/ports/' . self::PORT_ID, null, [], 'port_get');
 
         $this->port->retrieve();
-        $this->assertEquals('46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2', $this->port->id);
-        $this->assertEquals('ACTIVE', $this->port->status);
-        $this->assertEquals('port-name', $this->port->name);
-        $this->assertEquals(true, $this->port->adminStateUp);
-        $this->assertEquals(true,$this->port->portSecurityEnabled);
-        $this->assertEquals('network:router_interface', $this->port->deviceOwner);
-        $this->assertEquals('fake-device-id', $this->port->deviceId);
-        $this->assertEquals('00:11:22:33:44:55', $this->port->macAddress);
-        $this->assertCount(1, $this->port->fixedIps);
+        self::assertEquals('46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2', $this->port->id);
+        self::assertEquals('ACTIVE', $this->port->status);
+        self::assertEquals('port-name', $this->port->name);
+        self::assertEquals(true, $this->port->adminStateUp);
+        self::assertEquals(true,$this->port->portSecurityEnabled);
+        self::assertEquals('network:router_interface', $this->port->deviceOwner);
+        self::assertEquals('fake-device-id', $this->port->deviceId);
+        self::assertEquals('00:11:22:33:44:55', $this->port->macAddress);
+        self::assertCount(1, $this->port->fixedIps);
     }
 
     public function test_it_deletes()

--- a/tests/unit/Networking/v2/Models/QuotaTest.php
+++ b/tests/unit/Networking/v2/Models/QuotaTest.php
@@ -15,7 +15,7 @@ class QuotaTest extends TestCase
     /** @var Port */
     private $quota;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/Networking/v2/Models/SubnetTest.php
+++ b/tests/unit/Networking/v2/Models/SubnetTest.php
@@ -11,7 +11,7 @@ class SubnetTest extends TestCase
 {
     private $subnet;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -88,7 +88,7 @@ class SubnetTest extends TestCase
 
         $subnets = $this->subnet->bulkCreate($opts);
 
-        $this->assertInternalType('array', $subnets);
+        self::assertIsArray($subnets);
         $this->assertCount(2, $subnets);
     }
 

--- a/tests/unit/Networking/v2/Models/SubnetTest.php
+++ b/tests/unit/Networking/v2/Models/SubnetTest.php
@@ -43,7 +43,7 @@ class SubnetTest extends TestCase
 
         $this->setupMock('POST', 'v2.0/subnets', $expectedJson, ['Content-Type' => 'application/json'], 'subnet-post');
 
-        $this->assertInstanceOf(Subnet::class, $this->subnet->create($opts));
+        self::assertInstanceOf(Subnet::class, $this->subnet->create($opts));
     }
 
     public function test_it_bulk_creates()
@@ -89,7 +89,7 @@ class SubnetTest extends TestCase
         $subnets = $this->subnet->bulkCreate($opts);
 
         self::assertIsArray($subnets);
-        $this->assertCount(2, $subnets);
+        self::assertCount(2, $subnets);
     }
 
     public function test_it_updates()
@@ -114,10 +114,10 @@ class SubnetTest extends TestCase
 
         $this->subnet->retrieve();
 
-        $this->assertEquals('subnetId', $this->subnet->id);
-        $this->assertEquals('192.0.0.0/8', $this->subnet->cidr);
-        $this->assertEquals('192.0.0.1', $this->subnet->gatewayIp);
-        $this->assertTrue($this->subnet->enableDhcp);
+        self::assertEquals('subnetId', $this->subnet->id);
+        self::assertEquals('192.0.0.0/8', $this->subnet->cidr);
+        self::assertEquals('192.0.0.1', $this->subnet->gatewayIp);
+        self::assertTrue($this->subnet->enableDhcp);
     }
 
     public function test_it_deletes()

--- a/tests/unit/Networking/v2/ServiceTest.php
+++ b/tests/unit/Networking/v2/ServiceTest.php
@@ -16,7 +16,7 @@ class ServiceTest extends TestCase
     /** @var  Service */
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -78,7 +78,7 @@ class ServiceTest extends TestCase
 
         $networks = $this->service->createNetworks($opts);
 
-        $this->assertInternalType('array', $networks);
+        self::assertIsArray($networks);
         $this->assertCount(2, $networks);
     }
 
@@ -167,7 +167,7 @@ class ServiceTest extends TestCase
 
         $subnets = $this->service->createSubnets($opts);
 
-        $this->assertInternalType('array', $subnets);
+        self::assertIsArray($subnets);
         $this->assertCount(2, $subnets);
     }
 
@@ -244,7 +244,7 @@ class ServiceTest extends TestCase
 
         $ports = $this->service->createPorts($opts);
 
-        $this->assertInternalType('array', $ports);
+        self::assertIsArray($ports);
         $this->assertCount(2, $ports);
     }
 

--- a/tests/unit/Networking/v2/ServiceTest.php
+++ b/tests/unit/Networking/v2/ServiceTest.php
@@ -41,7 +41,7 @@ class ServiceTest extends TestCase
 
         $this->setupMock('POST', 'v2.0/networks', $expectedJson, [], 'network-post');
 
-        $this->assertInstanceOf(Network::class, $this->service->createNetwork($opts));
+        self::assertInstanceOf(Network::class, $this->service->createNetwork($opts));
     }
 
     public function test_it_bulk_creates_networks()
@@ -79,15 +79,15 @@ class ServiceTest extends TestCase
         $networks = $this->service->createNetworks($opts);
 
         self::assertIsArray($networks);
-        $this->assertCount(2, $networks);
+        self::assertCount(2, $networks);
     }
 
     public function test_it_gets_an_network()
     {
         $network = $this->service->getNetwork('networkId');
 
-        $this->assertInstanceOf(Network::class, $network);
-        $this->assertEquals('networkId', $network->id);
+        self::assertInstanceOf(Network::class, $network);
+        self::assertEquals('networkId', $network->id);
     }
 
     public function test_it_lists_networks()
@@ -98,7 +98,7 @@ class ServiceTest extends TestCase
             ->willReturn($this->getFixture('networks-post'));
 
         foreach ($this->service->listNetworks() as $network) {
-            $this->assertInstanceOf(Network::class, $network);
+            self::assertInstanceOf(Network::class, $network);
         }
     }
 
@@ -122,7 +122,7 @@ class ServiceTest extends TestCase
 
         $this->setupMock('POST', 'v2.0/subnets', $expectedJson, ['Content-Type' => 'application/json'], 'subnet-post');
 
-        $this->assertInstanceOf(Subnet::class, $this->service->createSubnet($opts));
+        self::assertInstanceOf(Subnet::class, $this->service->createSubnet($opts));
     }
 
     public function test_it_bulk_creates_subnets()
@@ -168,15 +168,15 @@ class ServiceTest extends TestCase
         $subnets = $this->service->createSubnets($opts);
 
         self::assertIsArray($subnets);
-        $this->assertCount(2, $subnets);
+        self::assertCount(2, $subnets);
     }
 
     public function test_it_gets_an_subnet()
     {
         $subnet = $this->service->getSubnet('subnetId');
 
-        $this->assertInstanceOf(Subnet::class, $subnet);
-        $this->assertEquals('subnetId', $subnet->id);
+        self::assertInstanceOf(Subnet::class, $subnet);
+        self::assertEquals('subnetId', $subnet->id);
     }
 
     public function test_it_lists_subnets()
@@ -187,7 +187,7 @@ class ServiceTest extends TestCase
             ->willReturn($this->getFixture('subnets-post'));
 
         foreach ($this->service->listSubnets() as $subnet) {
-            $this->assertInstanceOf(Subnet::class, $subnet);
+            self::assertInstanceOf(Subnet::class, $subnet);
         }
     }
 
@@ -207,7 +207,7 @@ class ServiceTest extends TestCase
 
         $this->setupMock('POST', 'v2.0/ports', $expectedJson, [], 'ports_post');
 
-        $this->assertInstanceOf(Port::class, $this->service->createPort($opts));
+        self::assertInstanceOf(Port::class, $this->service->createPort($opts));
     }
 
     public function test_it_bulk_creates_ports()
@@ -245,15 +245,15 @@ class ServiceTest extends TestCase
         $ports = $this->service->createPorts($opts);
 
         self::assertIsArray($ports);
-        $this->assertCount(2, $ports);
+        self::assertCount(2, $ports);
     }
 
     public function test_it_gets_an_port()
     {
         $port = $this->service->getPort('portId');
 
-        $this->assertInstanceOf(Port::class, $port);
-        $this->assertEquals('portId', $port->id);
+        self::assertInstanceOf(Port::class, $port);
+        self::assertEquals('portId', $port->id);
     }
 
     public function test_it_lists_ports()
@@ -264,7 +264,7 @@ class ServiceTest extends TestCase
             ->willReturn($this->getFixture('ports_get'));
 
         foreach ($this->service->listPorts() as $port) {
-            $this->assertInstanceOf(Port::class, $port);
+            self::assertInstanceOf(Port::class, $port);
         }
     }
 
@@ -276,7 +276,7 @@ class ServiceTest extends TestCase
             ->willReturn($this->getFixture('quotas-get'));
 
         foreach ($this->service->listQuotas() as $quota) {
-            $this->assertInstanceOf(Quota::class, $quota);
+            self::assertInstanceOf(Quota::class, $quota);
         }
     }
 
@@ -290,7 +290,7 @@ class ServiceTest extends TestCase
         $quota = $this->service->getQuota('fake_tenant_id');
         $quota->retrieve();
 
-        $this->assertInstanceOf(Quota::class, $quota);
+        self::assertInstanceOf(Quota::class, $quota);
     }
 
     public function test_it_gets_default_quotas()

--- a/tests/unit/ObjectStore/v1/Models/AccountTest.php
+++ b/tests/unit/ObjectStore/v1/Models/AccountTest.php
@@ -10,7 +10,7 @@ class AccountTest extends TestCase
 {
     private $account;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/ObjectStore/v1/Models/AccountTest.php
+++ b/tests/unit/ObjectStore/v1/Models/AccountTest.php
@@ -25,10 +25,10 @@ class AccountTest extends TestCase
 
         $this->account->populateFromResponse($response);
 
-        $this->assertEquals(1, $this->account->objectCount);
-        $this->assertEquals(['Book' => 'MobyDick', 'Genre' => 'Fiction'], $this->account->metadata);
-        $this->assertEquals(14, $this->account->bytesUsed);
-        $this->assertEquals(2, $this->account->containerCount);
+        self::assertEquals(1, $this->account->objectCount);
+        self::assertEquals(['Book' => 'MobyDick', 'Genre' => 'Fiction'], $this->account->metadata);
+        self::assertEquals(14, $this->account->bytesUsed);
+        self::assertEquals(2, $this->account->containerCount);
     }
 
     public function test_Retrieve()
@@ -37,13 +37,13 @@ class AccountTest extends TestCase
 
         $this->account->retrieve();
 
-        $this->assertNotEmpty($this->account->metadata);
+        self::assertNotEmpty($this->account->metadata);
     }
 
     public function test_Get_Metadata()
     {
         $this->setupMock('HEAD', '', null, [], 'HEAD_Account');
-        $this->assertEquals(['Book' => 'MobyDick', 'Genre' => 'Fiction'], $this->account->getMetadata());
+        self::assertEquals(['Book' => 'MobyDick', 'Genre' => 'Fiction'], $this->account->getMetadata());
     }
 
     public function test_Merge_Metadata()

--- a/tests/unit/ObjectStore/v1/Models/ContainerTest.php
+++ b/tests/unit/ObjectStore/v1/Models/ContainerTest.php
@@ -34,9 +34,9 @@ class ContainerTest extends TestCase
 
         $this->container->populateFromResponse($response);
 
-        $this->assertEquals(1, $this->container->objectCount);
-        $this->assertEquals(['Book' => 'TomSawyer', 'Author' => 'SamuelClemens'], $this->container->metadata);
-        $this->assertEquals(14, $this->container->bytesUsed);
+        self::assertEquals(1, $this->container->objectCount);
+        self::assertEquals(['Book' => 'TomSawyer', 'Author' => 'SamuelClemens'], $this->container->metadata);
+        self::assertEquals(14, $this->container->bytesUsed);
     }
 
     public function test_Retrieve()
@@ -44,14 +44,14 @@ class ContainerTest extends TestCase
         $this->setupMock('HEAD', self::NAME, null, [], 'HEAD_Container');
 
         $this->container->retrieve();
-        $this->assertNotEmpty($this->container->metadata);
+        self::assertNotEmpty($this->container->metadata);
     }
 
     public function test_Get_Metadata()
     {
         $this->setupMock('HEAD', self::NAME, null, [], 'HEAD_Container');
 
-        $this->assertEquals(['Book' => 'TomSawyer', 'Author' => 'SamuelClemens'], $this->container->getMetadata());
+        self::assertEquals(['Book' => 'TomSawyer', 'Author' => 'SamuelClemens'], $this->container->getMetadata());
     }
 
     public function test_Merge_Metadata()
@@ -95,8 +95,8 @@ class ContainerTest extends TestCase
     {
         $object = $this->container->getObject('foo.txt');
 
-        $this->assertInstanceOf(StorageObject::class, $object);
-        $this->assertEquals('foo.txt', $object->name);
+        self::assertInstanceOf(StorageObject::class, $object);
+        self::assertEquals('foo.txt', $object->name);
     }
 
     public function test_It_Create_Objects()
@@ -127,8 +127,8 @@ class ContainerTest extends TestCase
             'metadata'           => ['Author' => 'foo', 'genre' => 'bar'],
         ]);
 
-        $this->assertEquals('foo.txt', $storageObject->name);
-        $this->assertEquals(self::NAME, $storageObject->containerName);
+        self::assertEquals('foo.txt', $storageObject->name);
+        self::assertEquals(self::NAME, $storageObject->containerName);
     }
 
     public function test_it_lists_objects()
@@ -140,7 +140,7 @@ class ContainerTest extends TestCase
 
         $objects = iterator_to_array($this->container->listObjects(['limit' => 2]));
 
-        $this->assertEquals(2, count($objects));
+        self::assertEquals(2, count($objects));
 
         $expected = [
             [
@@ -167,7 +167,7 @@ class ContainerTest extends TestCase
 
             foreach ($exp as $attr => $attrVal)
             {
-                $this->assertEquals($attrVal, $obj->{$attr});
+                self::assertEquals($attrVal, $obj->{$attr});
             }
         }
     }
@@ -176,7 +176,7 @@ class ContainerTest extends TestCase
     {
         $this->setupMock('HEAD', 'test/bar', null, [], new Response(200));
 
-        $this->assertTrue($this->container->objectExists('bar'));
+        self::assertTrue($this->container->objectExists('bar'));
     }
 
     public function test_false_is_returned_for_non_existing_object()
@@ -190,7 +190,7 @@ class ContainerTest extends TestCase
             ->shouldBeCalled()
             ->willThrow($e);
 
-        $this->assertFalse($this->container->objectExists('bar'));
+        self::assertFalse($this->container->objectExists('bar'));
     }
 
     public function test_other_exceptions_are_thrown()

--- a/tests/unit/ObjectStore/v1/Models/ContainerTest.php
+++ b/tests/unit/ObjectStore/v1/Models/ContainerTest.php
@@ -18,7 +18,7 @@ class ContainerTest extends TestCase
 
     private $container;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -193,9 +193,6 @@ class ContainerTest extends TestCase
         $this->assertFalse($this->container->objectExists('bar'));
     }
 
-    /**
-     * @expectedException \OpenStack\Common\Error\BadResponseError
-     */
     public function test_other_exceptions_are_thrown()
     {
         $e = new BadResponseError();
@@ -206,6 +203,7 @@ class ContainerTest extends TestCase
             ->request('HEAD', 'test/bar', ['headers' => []])
             ->shouldBeCalled()
             ->willThrow($e);
+		$this->expectException(BadResponseError::class);
 
         $this->container->objectExists('bar');
     }

--- a/tests/unit/ObjectStore/v1/Models/ObjectTest.php
+++ b/tests/unit/ObjectStore/v1/Models/ObjectTest.php
@@ -15,7 +15,7 @@ class ObjectTest extends TestCase
 
     private $object;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/ObjectStore/v1/Models/ObjectTest.php
+++ b/tests/unit/ObjectStore/v1/Models/ObjectTest.php
@@ -59,14 +59,14 @@ class ObjectTest extends TestCase
         $this->setupMock('HEAD', self::CONTAINER . '/' . self::NAME, null, [], 'HEAD_Object');
 
         $this->object->retrieve();
-        $this->assertNotEmpty($this->object->metadata);
+        self::assertNotEmpty($this->object->metadata);
     }
 
     public function test_Get_Metadata()
     {
         $this->setupMock('HEAD', self::CONTAINER . '/' . self::NAME, null, [], 'HEAD_Object');
 
-        $this->assertEquals([
+        self::assertEquals([
             'Book'         => 'GoodbyeColumbus',
             'Manufacturer' => 'Acme',
         ], $this->object->getMetadata());
@@ -108,8 +108,8 @@ class ObjectTest extends TestCase
 
         $stream = $this->object->download();
 
-        $this->assertInstanceOf(Stream::class, $stream);
-        $this->assertEquals(14, $stream->getSize());
+        self::assertInstanceOf(Stream::class, $stream);
+        self::assertEquals(14, $stream->getSize());
     }
 
     public function test_It_Copies()
@@ -133,6 +133,6 @@ class ObjectTest extends TestCase
         $this->object->containerName = 'foo';
         $this->object->name = 'bar';
 
-        $this->assertEquals(uri_for('myopenstack.org:9000/tenantId/foo/bar'), $this->object->getPublicUri());
+        self::assertEquals(uri_for('myopenstack.org:9000/tenantId/foo/bar'), $this->object->getPublicUri());
     }
 }

--- a/tests/unit/ObjectStore/v1/ServiceTest.php
+++ b/tests/unit/ObjectStore/v1/ServiceTest.php
@@ -15,7 +15,7 @@ class ServiceTest extends TestCase
 {
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -68,9 +68,6 @@ class ServiceTest extends TestCase
         $this->assertFalse($this->service->containerExists('foo'));
     }
 
-    /**
-     * @expectedException \OpenStack\Common\Error\BadResponseError
-     */
     public function test_it_throws_exception_when_error()
     {
         $e = new BadResponseError();
@@ -81,7 +78,8 @@ class ServiceTest extends TestCase
             ->request('HEAD', 'foo', ['headers' => []])
             ->shouldBeCalled()
             ->willThrow($e);
+		$this->expectException(BadResponseError::class);
 
-        $this->assertFalse($this->service->containerExists('foo'));
+        $this->service->containerExists('foo');
     }
 }

--- a/tests/unit/ObjectStore/v1/ServiceTest.php
+++ b/tests/unit/ObjectStore/v1/ServiceTest.php
@@ -26,7 +26,7 @@ class ServiceTest extends TestCase
 
     public function test_Account()
     {
-        $this->assertInstanceOf(Account::class, $this->service->getAccount());
+        self::assertInstanceOf(Account::class, $this->service->getAccount());
     }
 
     public function test_it_lists_containers()
@@ -37,7 +37,7 @@ class ServiceTest extends TestCase
             ->willReturn($this->getFixture('GET_Container'));
 
         foreach ($this->service->listContainers(['limit' => 2]) as $container) {
-            $this->assertInstanceOf(Container::class, $container);
+            self::assertInstanceOf(Container::class, $container);
         }
     }
 
@@ -51,7 +51,7 @@ class ServiceTest extends TestCase
     {
         $this->setupMock('HEAD', 'foo', null, [], new Response(200));
 
-        $this->assertTrue($this->service->containerExists('foo'));
+        self::assertTrue($this->service->containerExists('foo'));
     }
 
     public function test_it_returns_false_if_container_does_not_exist()
@@ -65,7 +65,7 @@ class ServiceTest extends TestCase
             ->shouldBeCalled()
             ->willThrow($e);
 
-        $this->assertFalse($this->service->containerExists('foo'));
+        self::assertFalse($this->service->containerExists('foo'));
     }
 
     public function test_it_throws_exception_when_error()

--- a/tests/unit/OpenStackTest.php
+++ b/tests/unit/OpenStackTest.php
@@ -23,7 +23,7 @@ class OpenStackTest extends TestCase
     /** @var OpenStack */
     private $openstack;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->builder = $this->prophesize(Builder::class);
         $this->openstack = new OpenStack(['authUrl' => ''], $this->builder->reveal());
@@ -58,7 +58,7 @@ class OpenStackTest extends TestCase
 
         $this->openstack->identityV3();
     }
-    
+
     public function test_it_supports_networking_v2()
     {
         $this->builder

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -18,7 +18,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     protected $api;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->client = $this->prophesize(ClientInterface::class);
     }
@@ -43,7 +43,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         return parse_response(file_get_contents($path));
     }
 
-    protected function setupMock($method, $path, $body = null, array $headers = [], $response)
+    protected function setupMock($method, $path, $body = null, array $headers = [], $response = null)
     {
         $options = ['headers' => $headers];
 

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -77,23 +77,23 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
         $resources = call_user_func($call);
 
-        $this->assertInstanceOf('\Generator', $resources);
+        self::assertInstanceOf('\Generator', $resources);
 
         $count = 0;
 
         foreach ($resources as $resource) {
-            $this->assertInstanceOf('OpenStack\Identity\v3\Models\\' . ucfirst($modelName), $resource);
+            self::assertInstanceOf('OpenStack\Identity\v3\Models\\' . ucfirst($modelName), $resource);
             ++$count;
         }
 
-        $this->assertEquals(2, $count);
+        self::assertEquals(2, $count);
     }
 
     protected function getTest(callable $call, $modelName)
     {
         $resource = call_user_func($call);
 
-        $this->assertInstanceOf('OpenStack\Identity\v3\Models\\' . ucfirst($modelName), $resource);
-        $this->assertEquals('id', $resource->id);
+        self::assertInstanceOf('OpenStack\Identity\v3\Models\\' . ucfirst($modelName), $resource);
+        self::assertEquals('id', $resource->id);
     }
 }


### PR DESCRIPTION
This builds on https://github.com/php-opencloud/openstack/pull/324.

This also resolves all wrong method calls with the new phpunit and fixes and code/markup that triggers phpunit warnings otherwise. This will ease the upgrade to phpunit9.