### PR TITLE
Fix Call to undefined function GuzzleHttp\Psr7\modify_request()

### DIFF
--- a/src/Common/Auth/AuthHandler.php
+++ b/src/Common/Auth/AuthHandler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OpenStack\Common\Auth;
 
-use function GuzzleHttp\Psr7\modify_request;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -53,7 +53,7 @@ class AuthHandler
 
         $modify = ['set_headers' => ['X-Auth-Token' => $this->token->getId()]];
 
-        return $fn(modify_request($request, $modify), $options);
+        return $fn(Utils::modifyRequest($request, $modify), $options);
     }
 
     /**

--- a/tests/unit/Common/Api/OperatorTraitTest.php
+++ b/tests/unit/Common/Api/OperatorTraitTest.php
@@ -2,7 +2,6 @@
 
 namespace OpenStack\Test\Common\Api;
 
-use function GuzzleHttp\Psr7\uri_for;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Psr7\Response;
 use OpenStack\Common\Api\Operation;

--- a/tests/unit/Common/Error/BuilderTest.php
+++ b/tests/unit/Common/Error/BuilderTest.php
@@ -2,13 +2,11 @@
 
 namespace OpenStack\Test\Common\Error;
 
-use function GuzzleHttp\Psr7\stream_for;
-use function GuzzleHttp\Psr7\str;
-
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use OpenStack\Common\Error\BadResponseError;
 use OpenStack\Common\Error\Builder;
 use OpenStack\Common\Error\UserInputError;
@@ -32,7 +30,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
     public function test_it_builds_http_errors()
     {
         $request = new Request('POST', '/servers');
-        $response = new Response(400, [], stream_for('Invalid parameters'));
+        $response = new Response(400, [], Utils::streamFor('Invalid parameters'));
 
         $requestStr = trim($this->builder->str($request));
         $responseStr = trim($this->builder->str($response));

--- a/tests/unit/Common/Resource/AbstractResourceTest.php
+++ b/tests/unit/Common/Resource/AbstractResourceTest.php
@@ -3,7 +3,7 @@
 namespace OpenStack\Test\Common\Resource;
 
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\stream_for;
+use GuzzleHttp\Psr7\Utils;
 use OpenStack\Common\Resource\AbstractResource;
 use OpenStack\Common\Resource\Alias;
 use OpenStack\Common\Resource\ResourceInterface;
@@ -25,7 +25,7 @@ class AbstractResourceTest extends TestCase
 
     public function test_it_populates_from_response()
     {
-        $response = new Response(200, ['Content-Type' => 'application/json'], stream_for(
+        $response = new Response(200, ['Content-Type' => 'application/json'], Utils::streamFor(
             json_encode(['foo' => ['bar' => '1']])
         ));
 

--- a/tests/unit/Common/Transport/UtilsTest.php
+++ b/tests/unit/Common/Transport/UtilsTest.php
@@ -3,8 +3,8 @@
 namespace OpenStack\Test\Common\Transport;
 
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\uri_for;
 use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\Utils as Psr7Utils;
 use OpenStack\Common\Transport\Utils;
 use OpenStack\Test\TestCase;
 
@@ -12,7 +12,7 @@ class UtilsTest extends TestCase
 {
     public function test_decoding_malformed_json_throws_error()
     {
-        $response = new Response(200, [], \GuzzleHttp\Psr7\stream_for('{'));
+        $response = new Response(200, [], Psr7Utils::streamFor('{'));
 		$this->expectException(\InvalidArgumentException::class);
 
         Utils::jsonDecode($response);
@@ -20,9 +20,9 @@ class UtilsTest extends TestCase
 
     public function test_it_adds_paths()
     {
-        $uri = Utils::addPaths(uri_for('http://openstack.org/foo'), 'bar', 'baz', '1', '2');
+        $uri = Utils::addPaths(Psr7Utils::uriFor('http://openstack.org/foo'), 'bar', 'baz', '1', '2');
 
         self::assertInstanceOf(Uri::class, $uri);
-        self::assertEquals(uri_for('http://openstack.org/foo/bar/baz/1/2'), $uri);
+        self::assertEquals(Psr7Utils::uriFor('http://openstack.org/foo/bar/baz/1/2'), $uri);
     }
 }

--- a/tests/unit/ObjectStore/v1/Models/ObjectTest.php
+++ b/tests/unit/ObjectStore/v1/Models/ObjectTest.php
@@ -2,8 +2,8 @@
 
 namespace OpenStack\Test\ObjectStore\v1\Models;
 
-use function GuzzleHttp\Psr7\uri_for;
 use GuzzleHttp\Psr7\Stream;
+use GuzzleHttp\Psr7\Utils;
 use OpenStack\ObjectStore\v1\Api;
 use OpenStack\ObjectStore\v1\Models\StorageObject;
 use OpenStack\Test\TestCase;
@@ -128,11 +128,11 @@ class ObjectTest extends TestCase
     {
         $this->client->getConfig('base_uri')
             ->shouldBeCalled()
-            ->willReturn(uri_for('myopenstack.org:9000/tenantId'));
+            ->willReturn(Utils::uriFor('myopenstack.org:9000/tenantId'));
 
         $this->object->containerName = 'foo';
         $this->object->name = 'bar';
 
-        self::assertEquals(uri_for('myopenstack.org:9000/tenantId/foo/bar'), $this->object->getPublicUri());
+        self::assertEquals(Utils::uriFor('myopenstack.org:9000/tenantId/foo/bar'), $this->object->getPublicUri());
     }
 }

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -2,10 +2,10 @@
 
 namespace OpenStack\Test;
 
-use function GuzzleHttp\Psr7\stream_for;
-use function GuzzleHttp\Psr7\parse_response;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Message;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use Prophecy\Argument;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
@@ -25,7 +25,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     protected function createResponse($status, array $headers, array $json)
     {
-        return new Response($status, $headers, stream_for(json_encode($json)));
+        return new Response($status, $headers, Utils::streamFor(json_encode($json)));
     }
 
     protected function getFixture($file)
@@ -40,7 +40,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             throw new \RuntimeException(sprintf("%s does not exist", $path));
         }
 
-        return parse_response(file_get_contents($path));
+        return Message::parseResponse(file_get_contents($path));
     }
 
     protected function setupMock($method, $path, $body = null, array $headers = [], $response = null)


### PR DESCRIPTION
I needed to do this change in order to prevent this error `Call to undefined function GuzzleHttp\Psr7\modify_request()`.

This PR removes deprecated calls to guzzle functions.

I checked all the code, and this was the only missing call to `GuzzleHttp\Psr7\` deprecated functions. I updated the unit tests.