### PR TITLE
Fix error Call to undefined function GuzzleHttp\Psr7\modify_request()

### DIFF
--- a/src/Common/Auth/AuthHandler.php
+++ b/src/Common/Auth/AuthHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OpenStack\Common\Auth;
 
-use function GuzzleHttp\Psr7\modify_request;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -53,7 +52,7 @@ class AuthHandler
 
         $modify = ['set_headers' => ['X-Auth-Token' => $this->token->getId()]];
 
-        return $fn(modify_request($request, $modify), $options);
+        return $fn(\GuzzleHttp\Psr7\Utils::modifyRequest($request, $modify), $options);
     }
 
     /**


### PR DESCRIPTION
Function modify_request() is deprecated in GuzzleHttp\Psr7, now calling this function will generate the error Call to undefined function GuzzleHttp\Psr7\modify_request().

This PR replace this function to \GuzzleHttp\Psr7\Utils::modifyRequest