### PR TITLE
Fixes issues with guzzle psr7 compliance

### DIFF
--- a/samples/images/v2/images/upload_binary_data.php
+++ b/samples/images/v2/images/upload_binary_data.php
@@ -1,5 +1,7 @@
 <?php
 
+use GuzzleHttp\Psr7\Utils;
+
 require 'vendor/autoload.php';
 
 $openstack = new OpenStack\OpenStack([
@@ -12,5 +14,5 @@ $openstack = new OpenStack\OpenStack([
 $service = $openstack->imagesV2();
 
 $image  = $service->getImage('{imageId}');
-$stream = \GuzzleHttp\Psr7\stream_for(fopen('{fileName}', 'r'));
+$stream = Utils::streamFor(fopen('{fileName}', 'r'));
 $image->uploadData($stream);

--- a/src/Common/Service/Builder.php
+++ b/src/Common/Service/Builder.php
@@ -6,10 +6,11 @@ namespace OpenStack\Common\Service;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware as GuzzleMiddleware;
 use OpenStack\Common\Auth\IdentityService;
 use OpenStack\Common\Auth\Token;
-use OpenStack\Common\Transport\HandlerStack;
+use OpenStack\Common\Transport\HandlerStackFactory;
 use OpenStack\Common\Transport\Middleware;
 use OpenStack\Common\Transport\Utils;
 
@@ -132,7 +133,7 @@ class Builder
 
     private function getStack(callable $authHandler, Token $token = null): HandlerStack
     {
-        $stack = HandlerStack::create();
+        $stack = HandlerStackFactory::create();
         $stack->push(Middleware::authHandler($authHandler, $token));
 
         return $stack;

--- a/src/Common/Transport/HandlerStackFactory.php
+++ b/src/Common/Transport/HandlerStackFactory.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace OpenStack\Common\Transport;
 
-use GuzzleHttp\HandlerStack as GuzzleStack;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Utils;
 
-class HandlerStack extends GuzzleStack
+class HandlerStackFactory
 {
-    public static function create(?callable $handler = null): GuzzleStack
+    public static function create(?callable $handler = null): HandlerStack
     {
-        $stack = new self($handler ?: Utils::chooseHandler());
+        $stack = new HandlerStack($handler ?: Utils::chooseHandler());
         $stack->push(Middleware::httpErrors(), 'http_errors');
         $stack->push(Middleware::prepareBody(), 'prepare_body');
 

--- a/src/OpenStack.php
+++ b/src/OpenStack.php
@@ -7,7 +7,7 @@ namespace OpenStack;
 use GuzzleHttp\Client;
 use GuzzleHttp\Middleware as GuzzleMiddleware;
 use OpenStack\Common\Service\Builder;
-use OpenStack\Common\Transport\HandlerStack;
+use OpenStack\Common\Transport\HandlerStackFactory;
 use OpenStack\Common\Transport\Utils;
 use OpenStack\Identity\v3\Service;
 
@@ -50,7 +50,7 @@ class OpenStack
             throw new \InvalidArgumentException("'authUrl' is a required option");
         }
 
-        $stack = HandlerStack::create();
+        $stack = HandlerStackFactory::create();
 
         if (!empty($options['debugLog'])
             && !empty($options['logger'])

--- a/tests/unit/Common/Resource/OperatorResourceTest.php
+++ b/tests/unit/Common/Resource/OperatorResourceTest.php
@@ -4,6 +4,7 @@ namespace OpenStack\Test\Common\Resource;
 
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\Utils;
 use OpenStack\Common\Resource\OperatorResource;
 use OpenStack\Common\Resource\ResourceInterface;
 use OpenStack\Test\Common\Service\Fixtures\Api;
@@ -28,7 +29,7 @@ class OperatorResourceTest extends TestCase
 
     public function test_it_retrieves_base_http_url()
     {
-        $returnedUri = \GuzzleHttp\Psr7\uri_for('http://foo.com');
+        $returnedUri = Utils::uriFor('http://foo.com');
         $this->client->getConfig('base_uri')->shouldBeCalled()->willReturn($returnedUri);
 
         $uri = $this->resource->testBaseUri();

--- a/tests/unit/Common/Transport/HandlerStackTest.php
+++ b/tests/unit/Common/Transport/HandlerStackTest.php
@@ -3,13 +3,14 @@
 namespace OpenStack\Test\Common\Transport;
 
 use GuzzleHttp\Handler\MockHandler;
-use OpenStack\Common\Transport\HandlerStack;
+use GuzzleHttp\HandlerStack;
+use OpenStack\Common\Transport\HandlerStackFactory;
 use OpenStack\Test\TestCase;
 
 class HandlerStackTest extends TestCase
 {
     public function test_it_is_created()
     {
-        self::assertInstanceOf(HandlerStack::class, HandlerStack::create(new MockHandler()));
+        self::assertInstanceOf(HandlerStack::class, HandlerStackFactory::create(new MockHandler()));
     }
 }

--- a/tests/unit/Images/v2/Models/ImageTest.php
+++ b/tests/unit/Images/v2/Models/ImageTest.php
@@ -5,6 +5,7 @@ namespace OpensTack\Test\Images\v2\Models;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\Utils;
 use OpenStack\Images\v2\Api;
 use OpenStack\Images\v2\Models\Member;
 use OpenStack\Images\v2\Models\Image;
@@ -30,7 +31,7 @@ class ImageTest extends TestCase
 
     public function test_it_retrieves()
     {
-        $this->client->getConfig('base_uri')->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\uri_for(''));
+        $this->client->getConfig('base_uri')->shouldBeCalled()->willReturn(Utils::uriFor(''));
 
         $this->setupMock('GET', $this->path, null, [], 'GET_image');
 
@@ -123,7 +124,7 @@ class ImageTest extends TestCase
 
     public function test_it_uploads_data_stream()
     {
-        $stream  = \GuzzleHttp\Psr7\stream_for('data');
+        $stream  = Utils::streamFor('data');
         $headers = ['Content-Type' => 'application/octet-stream'];
 
         $this->setupMock('PUT', $this->path . '/file', $stream, $headers, new Response(204));
@@ -133,7 +134,7 @@ class ImageTest extends TestCase
 
     public function test_it_downloads_data()
     {
-        $stream  = \GuzzleHttp\Psr7\stream_for('data');
+        $stream  = Utils::streamFor('data');
         $headers = ['Content-Type' => 'application/octet-stream'];
         $response = new Response(200, $headers, $stream);
 

--- a/tests/unit/Images/v2/ServiceTest.php
+++ b/tests/unit/Images/v2/ServiceTest.php
@@ -3,6 +3,7 @@
 namespace OpenStack\Test\Images\v2;
 
 use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\Utils;
 use OpenStack\Images\v2\Api;
 use OpenStack\Images\v2\Models\Image;
 use OpenStack\Images\v2\Service;
@@ -26,7 +27,7 @@ class ServiceTest extends TestCase
         $this->client
             ->getConfig('base_uri')
             ->shouldBeCalled()
-            ->willReturn(\GuzzleHttp\Psr7\uri_for(''));
+            ->willReturn(Utils::uriFor(''));
 
         $expectedJson = [
             "name" => "Ubuntu 12.10",
@@ -61,7 +62,7 @@ class ServiceTest extends TestCase
         $this->client
             ->getConfig('base_uri')
             ->shouldBeCalled()
-            ->willReturn(\GuzzleHttp\Psr7\uri_for(''));
+            ->willReturn(Utils::uriFor(''));
 
         $this->client
             ->request('GET', 'v2/images', ['query' => ['limit' => 5], 'headers' => []])

--- a/tests/unit/ObjectStore/v1/Models/ContainerTest.php
+++ b/tests/unit/ObjectStore/v1/Models/ContainerTest.php
@@ -4,7 +4,7 @@ namespace OpenStack\Test\ObjectStore\v1\Models;
 
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Psr7\Stream;
+use GuzzleHttp\Psr7\Utils;
 use OpenStack\Common\Error\BadResponseError;
 use OpenStack\ObjectStore\v1\Api;
 use OpenStack\ObjectStore\v1\Models\Container;
@@ -211,7 +211,7 @@ class ContainerTest extends TestCase
     public function test_it_chunks_according_to_provided_segment_size()
     {
         /** @var \GuzzleHttp\Psr7\Stream $stream */
-        $stream = \GuzzleHttp\Psr7\stream_for(implode('', range('A', 'X')));
+        $stream = Utils::streamFor(implode('', range('A', 'X')));
 
         $data = [
             'name' => 'object',


### PR DESCRIPTION
- Changed guzzle final HandlerStack extension to factory class HandlerStackFactory
- Updated old guzzle psr7 utill functions to work with the new Utill
class functions