### PR TITLE
Add disassociatePort to FloatingIp

### DIFF
--- a/src/Networking/v2/Extensions/Layer3/Models/FloatingIp.php
+++ b/src/Networking/v2/Extensions/Layer3/Models/FloatingIp.php
@@ -79,4 +79,9 @@ class FloatingIp extends OperatorResource implements Listable, Creatable, Retrie
     {
         $this->execute($this->api->putFloatingIp(), ['id' => $this->id, 'portId' => $portId]);
     }
+    
+    public function disassociatePort()
+    {
+        $this->execute($this->api->putFloatingIp(), ['id' => $this->id, 'portId' => null]);
+    }
 }


### PR DESCRIPTION
Adds a disassociate method, as there is no way to send null as portId:

1. The method associatePort does not accept null value
2. The update method will not send to the api the portId if it has been nulled