### PR TITLE
allow uri-template 1.0 to be compatible with the latest Laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require": {
         "php": "^7.2.5|^8.0",
         "guzzlehttp/guzzle": "^7.0",
-        "guzzlehttp/uri-template": "0.2",
+        "guzzlehttp/uri-template": "^0.2|^1.0",
         "justinrainbow/json-schema": "^5.2"
     },
     "require-dev": {


### PR DESCRIPTION
Unlike https://github.com/php-opencloud/openstack/pull/356 this PR allows using uri-template 0.2 for backward compatibility. 
