### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+/.github export-ignore
+/doc export-ignore
+/samples export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php_cs.dist export-ignore
+/.scrutinizer.yml export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
Hello,

This PR add `.gitattributes` with `export-ignore` in order to reduce vendor size

More info here:
https://php.watch/articles/composer-gitattributes#export-ignore

With this change, vendor size goes from 5MB to 1.1MB