### PR TITLE
Fix container requests with "tokens" in its name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "justinrainbow/json-schema": "^5.2"
     },
     "require-dev": {
+        "ext-json": "*",
         "ergebnis/composer-normalize": "^2.0",
         "friendsofphp/php-cs-fixer": "^3",
         "php-coveralls/php-coveralls": "^2.0",

--- a/src/Common/Api/Operation.php
+++ b/src/Common/Api/Operation.php
@@ -27,6 +27,9 @@ class Operation
     /** @var []Parameter The parameters of this operation */
     private $params;
 
+    /** @var bool Whether this operation should skip authentication */
+    private $skipAuth;
+
     /**
      * @param array $definition The data definition (in array form) that will populate this
      *                          operation. Usually this is retrieved from an {@see ApiInterface}
@@ -42,6 +45,7 @@ class Operation
         }
 
         $this->params = self::toParamArray($definition['params']);
+        $this->skipAuth = $definition['skipAuth'] ?? false;
     }
 
     public function getPath(): string
@@ -55,9 +59,17 @@ class Operation
     }
 
     /**
+     * Indicates if operation must be run without authentication. This is useful for getting authentication tokens.
+     */
+    public function getSkipAuth(): bool
+    {
+        return $this->skipAuth;
+    }
+
+    /**
      * Indicates whether this operation supports a parameter.
      *
-     * @param $key The name of a parameter
+     * @param string $key The name of a parameter
      */
     public function hasParam(string $key): bool
     {

--- a/src/Common/Api/Operation.php
+++ b/src/Common/Api/Operation.php
@@ -44,7 +44,7 @@ class Operation
             $this->jsonKey = $definition['jsonKey'];
         }
 
-        $this->params = self::toParamArray($definition['params']);
+        $this->params   = self::toParamArray($definition['params']);
         $this->skipAuth = $definition['skipAuth'] ?? false;
     }
 

--- a/src/Common/Api/OperatorTrait.php
+++ b/src/Common/Api/OperatorTrait.php
@@ -105,9 +105,8 @@ trait OperatorTrait
             $options += $userValues['requestOptions'];
         }
 
-        if ($operation->getSkipAuth()) {
-            $options['openstack.skip_auth'] = true;
-        }
+        $options['openstack.skip_auth'] = $operation->getSkipAuth();
+        print_r($options);
 
         return $this->client->$method($operation->getMethod(), $uri, $options);
     }

--- a/src/Common/Api/OperatorTrait.php
+++ b/src/Common/Api/OperatorTrait.php
@@ -106,7 +106,6 @@ trait OperatorTrait
         }
 
         $options['openstack.skip_auth'] = $operation->getSkipAuth();
-        print_r($options);
 
         return $this->client->$method($operation->getMethod(), $uri, $options);
     }

--- a/src/Common/Api/OperatorTrait.php
+++ b/src/Common/Api/OperatorTrait.php
@@ -23,7 +23,7 @@ trait OperatorTrait
     public function __construct(ClientInterface $client, ApiInterface $api)
     {
         $this->client = $client;
-        $this->api = $api;
+        $this->api    = $api;
     }
 
     /**
@@ -56,7 +56,7 @@ trait OperatorTrait
      * following format: `createAsync`, where `create` is the sequential method being wrapped.
      *
      * @param string $methodName the name of the method being invoked
-     * @param array $args the arguments to be passed to the sequential method
+     * @param array  $args       the arguments to be passed to the sequential method
      *
      * @return Promise
      *
@@ -97,7 +97,7 @@ trait OperatorTrait
         $operation->validate($userValues);
 
         $options = (new RequestSerializer())->serializeOptions($operation, $userValues);
-        $method = $async ? 'requestAsync' : 'request';
+        $method  = $async ? 'requestAsync' : 'request';
 
         $uri = Utils::uri_template($operation->getPath(), $userValues);
 

--- a/src/Common/Api/OperatorTrait.php
+++ b/src/Common/Api/OperatorTrait.php
@@ -23,7 +23,7 @@ trait OperatorTrait
     public function __construct(ClientInterface $client, ApiInterface $api)
     {
         $this->client = $client;
-        $this->api    = $api;
+        $this->api = $api;
     }
 
     /**
@@ -55,8 +55,8 @@ trait OperatorTrait
      * {@see Promise} object. In order for this to happen, the called methods need to be in the
      * following format: `createAsync`, where `create` is the sequential method being wrapped.
      *
-     * @param $methodName the name of the method being invoked
-     * @param $args       the arguments to be passed to the sequential method
+     * @param string $methodName the name of the method being invoked
+     * @param array $args the arguments to be passed to the sequential method
      *
      * @return Promise
      *
@@ -92,20 +92,21 @@ trait OperatorTrait
         return new Operation($definition);
     }
 
-    /**
-     * @throws \Exception
-     */
     protected function sendRequest(Operation $operation, array $userValues = [], bool $async = false)
     {
         $operation->validate($userValues);
 
         $options = (new RequestSerializer())->serializeOptions($operation, $userValues);
-        $method  = $async ? 'requestAsync' : 'request';
+        $method = $async ? 'requestAsync' : 'request';
 
-        $uri     = Utils::uri_template($operation->getPath(), $userValues);
+        $uri = Utils::uri_template($operation->getPath(), $userValues);
 
         if (array_key_exists('requestOptions', $userValues)) {
             $options += $userValues['requestOptions'];
+        }
+
+        if ($operation->getSkipAuth()) {
+            $options['openstack.skip_auth'] = true;
         }
 
         return $this->client->$method($operation->getMethod(), $uri, $options);

--- a/src/Common/Auth/AuthHandler.php
+++ b/src/Common/Auth/AuthHandler.php
@@ -43,7 +43,7 @@ class AuthHandler
     {
         $fn = $this->nextHandler;
 
-        if ($this->shouldIgnore($request)) {
+        if (isset($options['openstack.skip_auth']) && $options['openstack.skip_auth']) {
             return $fn($request, $options);
         }
 
@@ -54,14 +54,5 @@ class AuthHandler
         $modify = ['set_headers' => ['X-Auth-Token' => $this->token->getId()]];
 
         return $fn(Utils::modifyRequest($request, $modify), $options);
-    }
-
-    /**
-     * Internal method which prevents infinite recursion. For certain requests, like the initial
-     * auth call itself, we do NOT want to send a token.
-     */
-    private function shouldIgnore(RequestInterface $request): bool
-    {
-        return false !== strpos((string) $request->getUri(), 'tokens') && 'POST' == $request->getMethod();
     }
 }

--- a/src/Common/Auth/AuthHandler.php
+++ b/src/Common/Auth/AuthHandler.php
@@ -43,12 +43,12 @@ class AuthHandler
     {
         $fn = $this->nextHandler;
 
-        if (!isset($options['openstack.skip_auth'])){
+        if (!isset($options['openstack.skip_auth'])) {
             // Deprecated. Left for backward compatibility only.
             if ($this->shouldIgnore($request)) {
                 return $fn($request, $options);
             }
-        } else if ($options['openstack.skip_auth']) {
+        } elseif ($options['openstack.skip_auth']) {
             return $fn($request, $options);
         }
 

--- a/src/Common/Service/Builder.php
+++ b/src/Common/Service/Builder.php
@@ -83,7 +83,7 @@ class Builder
         return new $serviceClass($options['httpClient'], new $apiClass());
     }
 
-    private function stockHttpClient(array &$options, string $serviceName)
+    private function stockHttpClient(array &$options, string $serviceName): void
     {
         if (!isset($options['httpClient']) || !($options['httpClient'] instanceof ClientInterface)) {
             if (false !== stripos($serviceName, 'identity')) {
@@ -105,7 +105,7 @@ class Builder
     /**
      * @codeCoverageIgnore
      */
-    private function addDebugMiddleware(array $options, HandlerStack &$stack)
+    private function addDebugMiddleware(array $options, HandlerStack &$stack): void
     {
         if (!empty($options['debugLog'])
             && !empty($options['logger'])
@@ -118,7 +118,7 @@ class Builder
     /**
      * @codeCoverageIgnore
      */
-    private function stockAuthHandler(array &$options)
+    private function stockAuthHandler(array &$options): void
     {
         if (!isset($options['authHandler'])) {
             $options['authHandler'] = function () use ($options) {

--- a/src/Identity/v2/Api.php
+++ b/src/Identity/v2/Api.php
@@ -14,20 +14,21 @@ class Api implements ApiInterface
     public function postToken(): array
     {
         return [
-            'method' => 'POST',
-            'path'   => 'tokens',
-            'params' => [
-                'username' => [
+            'method'   => 'POST',
+            'path'     => 'tokens',
+            'skipAuth' => true,
+            'params'   => [
+                'username'   => [
                     'type'     => 'string',
                     'required' => true,
                     'path'     => 'auth.passwordCredentials',
                 ],
-                'password' => [
+                'password'   => [
                     'type'     => 'string',
                     'required' => true,
                     'path'     => 'auth.passwordCredentials',
                 ],
-                'tenantId' => [
+                'tenantId'   => [
                     'type' => 'string',
                     'path' => 'auth',
                 ],

--- a/src/Identity/v3/Api.php
+++ b/src/Identity/v3/Api.php
@@ -16,9 +16,10 @@ class Api extends AbstractApi
     public function postTokens(): array
     {
         return [
-            'method' => 'POST',
-            'path'   => 'auth/tokens',
-            'params' => [
+            'method'   => 'POST',
+            'path'     => 'auth/tokens',
+            'skipAuth' => true,
+            'params'   => [
                 'methods'                => $this->params->methods(),
                 'user'                   => $this->params->user(),
                 'application_credential' => $this->params->applicationCredential(),

--- a/src/Identity/v3/Models/Token.php
+++ b/src/Identity/v3/Models/Token.php
@@ -89,27 +89,27 @@ class Token extends OperatorResource implements Creatable, Retrievable, \OpenSta
     }
 
     /**
-     * @param array $data {@see \OpenStack\Identity\v3\Api::postTokens}
+     * @param array $userOptions {@see \OpenStack\Identity\v3\Api::postTokens}
      */
-    public function create(array $data): Creatable
+    public function create(array $userOptions): Creatable
     {
-        if (isset($data['user'])) {
-            $data['methods'] = ['password'];
-            if (!isset($data['user']['id']) && empty($data['user']['domain'])) {
+        if (isset($userOptions['user'])) {
+            $userOptions['methods'] = ['password'];
+            if (!isset($userOptions['user']['id']) && empty($userOptions['user']['domain'])) {
                 throw new InvalidArgumentException('When authenticating with a username, you must also provide either the domain name '.'or domain ID to which the user belongs to. Alternatively, if you provide a user ID instead, '.'you do not need to provide domain information.');
             }
-        } elseif (isset($data['application_credential'])) {
-            $data['methods'] = ['application_credential'];
-            if (!isset($data['application_credential']['id']) || !isset($data['application_credential']['secret'])) {
+        } elseif (isset($userOptions['application_credential'])) {
+            $userOptions['methods'] = ['application_credential'];
+            if (!isset($userOptions['application_credential']['id']) || !isset($userOptions['application_credential']['secret'])) {
                 throw new InvalidArgumentException('When authenticating with a application_credential, you must provide application credential ID '.' and application credential secret.');
             }
-        } elseif (isset($data['tokenId'])) {
-            $data['methods'] = ['token'];
+        } elseif (isset($userOptions['tokenId'])) {
+            $userOptions['methods'] = ['token'];
         } else {
             throw new InvalidArgumentException('Either a user, tokenId or application_credential must be provided.');
         }
 
-        $response = $this->execute($this->api->postTokens(), $data);
+        $response = $this->execute($this->api->postTokens(), $userOptions);
         $token    = $this->populateFromResponse($response);
 
         // Cache response as an array to export if needed.

--- a/tests/sample/Compute/v2/TestCase.php
+++ b/tests/sample/Compute/v2/TestCase.php
@@ -68,7 +68,8 @@ abstract class TestCase extends \OpenStack\Sample\TestCase
             ]
         );
 
-        $server->waitUntilActive(60);
+        $server->waitUntilActive(120);
+        $this->assertEquals('ACTIVE', $server->status);
 
         return $server;
     }

--- a/tests/sample/ObjectStore/v1/ContainerTest.php
+++ b/tests/sample/ObjectStore/v1/ContainerTest.php
@@ -132,4 +132,13 @@ PHP
         $this->expectException(BadResponseError::class);
         $createdContainer->retrieve();
     }
+
+    public function testTokensContainer()
+    {
+        $container = $this->getService()->createContainer(['name' => $this->randomStr() . '_tokens']);
+        $this->assertNotNull($container->name);
+
+        // this would send POST request with 'tokens' in the URL
+        $container->resetMetadata([]);
+    }
 }

--- a/tests/unit/Common/Api/OperatorTraitTest.php
+++ b/tests/unit/Common/Api/OperatorTraitTest.php
@@ -44,7 +44,7 @@ class OperatorTraitTest extends TestCase
 
     public function test_it_sends_a_request_when_operations_are_executed()
     {
-        $this->client->request('GET', 'test', ['headers' => []])->willReturn(new Response());
+        $this->mockRequest('GET', 'test', new Response());
 
         $this->operator->execute($this->def, []);
 
@@ -53,7 +53,10 @@ class OperatorTraitTest extends TestCase
 
     public function test_it_sends_a_request_when_async_operations_are_executed()
     {
-        $this->client->requestAsync('GET', 'test', ['headers' => []])->willReturn(new Promise());
+        $this->client
+            ->requestAsync('GET', 'test', ['headers' => [], 'openstack.skip_auth' => false])
+            ->shouldBeCalled()
+            ->willReturn(new Promise());
 
         $this->operator->executeAsync($this->def, []);
 
@@ -75,13 +78,13 @@ class OperatorTraitTest extends TestCase
 
     public function test_it_throws_exception_when_async_is_called_on_a_non_existent_method()
     {
-		$this->expectException(\RuntimeException::class);
+        $this->expectException(\RuntimeException::class);
         $this->operator->fooAsync();
     }
 
     public function test_undefined_methods_result_in_error()
     {
-		$this->expectException(\Exception::class);
+        $this->expectException(\Exception::class);
         $this->operator->foo();
     }
 
@@ -103,15 +106,19 @@ class OperatorTraitTest extends TestCase
 
     public function test_guzzle_options_are_forwarded()
     {
-        $this->client->request('GET', 'test', ['headers' => [], 'stream' => true])->willReturn(new Response());
+        $this->client
+            ->request('GET', 'test', ['headers' => [], 'openstack.skip_auth' => false, 'stream' => true])
+            ->shouldBeCalled()
+            ->willReturn(new Response());
 
         $this->operator->execute($this->def, [
-            'requestOptions' => ['stream' => true]
+            'requestOptions' => ['stream' => true],
         ]);
 
         $this->addToAssertionCount(1);
     }
 }
+
 
 class TestResource extends AbstractResource
 {

--- a/tests/unit/Common/Api/OperatorTraitTest.php
+++ b/tests/unit/Common/Api/OperatorTraitTest.php
@@ -38,7 +38,7 @@ class OperatorTraitTest extends TestCase
     {
         self::assertInstanceOf(
             Operation::class,
-            $this->operator->getOperation($this->def, [])
+            $this->operator->getOperation($this->def)
         );
     }
 
@@ -46,9 +46,7 @@ class OperatorTraitTest extends TestCase
     {
         $this->mockRequest('GET', 'test', new Response());
 
-        $this->operator->execute($this->def, []);
-
-        $this->addToAssertionCount(1);
+        $this->operator->execute($this->def);
     }
 
     public function test_it_sends_a_request_when_async_operations_are_executed()
@@ -58,9 +56,7 @@ class OperatorTraitTest extends TestCase
             ->shouldBeCalled()
             ->willReturn(new Promise());
 
-        $this->operator->executeAsync($this->def, []);
-
-        $this->addToAssertionCount(1);
+        $this->operator->executeAsync($this->def);
     }
 
     public function test_it_wraps_sequential_ops_in_promise_when_async_is_appended_to_method_name()
@@ -114,8 +110,6 @@ class OperatorTraitTest extends TestCase
         $this->operator->execute($this->def, [
             'requestOptions' => ['stream' => true],
         ]);
-
-        $this->addToAssertionCount(1);
     }
 }
 

--- a/tests/unit/Common/Auth/AuthHandlerTest.php
+++ b/tests/unit/Common/Auth/AuthHandlerTest.php
@@ -35,7 +35,7 @@ class AuthHandlerTest extends TestCase
         // Fake a Keystone request
         $request = new Request('POST', 'https://my-openstack.org:5000/v2.0/tokens');
 
-        self::assertEquals($request, call_user_func_array($this->handler, [$request, []]));
+        self::assertEquals($request, call_user_func_array($this->handler, [$request, ['openstack.skip_auth' => true]]));
     }
 
     public function test_it_should_generate_a_new_token_if_the_current_token_is_either_expired_or_not_set()

--- a/tests/unit/Common/Auth/AuthHandlerTest.php
+++ b/tests/unit/Common/Auth/AuthHandlerTest.php
@@ -38,6 +38,14 @@ class AuthHandlerTest extends TestCase
         self::assertEquals($request, call_user_func_array($this->handler, [$request, ['openstack.skip_auth' => true]]));
     }
 
+    public function test_it_should_bypass_auth_http_requests_backward_compatibility()
+    {
+        // Fake a Keystone request
+        $request = new Request('POST', 'https://my-openstack.org:5000/v2.0/tokens');
+
+        self::assertEquals($request, call_user_func_array($this->handler, [$request, []]));
+    }
+
     public function test_it_should_generate_a_new_token_if_the_current_token_is_either_expired_or_not_set()
     {
         $token = $this->prophesize(Token::class);

--- a/tests/unit/Identity/v2/ServiceTest.php
+++ b/tests/unit/Identity/v2/ServiceTest.php
@@ -40,7 +40,7 @@ class ServiceTest extends TestCase
             'tenantId' => $options['tenantId'],
         ]];
 
-        $this->setupMock('POST', 'tokens', $expectedJson, [], 'token-post');
+        $this->setupMock('POST', 'tokens', $expectedJson, [], 'token-post', true);
 
         list($token, $baseUrl) = $this->service->authenticate($options);
 
@@ -64,7 +64,7 @@ class ServiceTest extends TestCase
             'tenantId' => $options['tenantId'],
         ]];
 
-        $this->setupMock('POST', 'tokens', $expectedJson, [], 'token-post');
+        $this->setupMock('POST', 'tokens', $expectedJson, [], 'token-post', true);
 
         self::assertInstanceOf(Token::class, $this->service->generateToken($options));
     }

--- a/tests/unit/Identity/v2/ServiceTest.php
+++ b/tests/unit/Identity/v2/ServiceTest.php
@@ -40,7 +40,7 @@ class ServiceTest extends TestCase
             'tenantId' => $options['tenantId'],
         ]];
 
-        $this->mockRequest('POST', 'tokens', 'token-post', $expectedJson, [], true;
+        $this->mockRequest('POST', 'tokens', 'token-post', $expectedJson, [], true);
 
         [$token, $baseUrl] = $this->service->authenticate($options);
 

--- a/tests/unit/Identity/v3/ServiceTest.php
+++ b/tests/unit/Identity/v3/ServiceTest.php
@@ -58,7 +58,7 @@ class ServiceTest extends TestCase
             ]
         ];
 
-        $this->setupMock('POST', 'auth/tokens', ['auth' => $expectedJson], [], 'token');
+        $this->setupMock('POST', 'auth/tokens', ['auth' => $expectedJson], [], 'token', true);
 
         list($token, $url) = $this->service->authenticate($userOptions);
 
@@ -231,7 +231,7 @@ class ServiceTest extends TestCase
             ]
         ];
 
-        $this->setupMock('POST', 'auth/tokens', ['auth' => $expectedJson], [], 'token');
+        $this->setupMock('POST', 'auth/tokens', ['auth' => $expectedJson], [], 'token', true);
 		$this->expectException(\RuntimeException::class);
 
         $this->service->authenticate([
@@ -629,7 +629,7 @@ class ServiceTest extends TestCase
             ]
         ];
 
-        $this->setupMock('POST', 'auth/tokens', ['auth' => $expectedJson], [], 'token');
+        $this->setupMock('POST', 'auth/tokens', ['auth' => $expectedJson], [], 'token', true);
 
         $token = $this->service->generateToken($userOptions);
         self::assertInstanceOf(Models\Token::class, $token);
@@ -654,7 +654,7 @@ class ServiceTest extends TestCase
             ]
         ];
 
-        $this->setupMock('POST', 'auth/tokens', ['auth' => $expectedJson], [], 'token');
+        $this->setupMock('POST', 'auth/tokens', ['auth' => $expectedJson], [], 'token', true);
 
         $token = $this->service->generateToken($userOptions);
         self::assertInstanceOf(Models\Token::class, $token);

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -42,7 +42,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         return Message::parseResponse(file_get_contents($path));
     }
 
-    protected function setupMock($method, $path, $body = null, array $headers = [], $response = null)
+    protected function setupMock($method, $path, $body = null, array $headers = [], $response = null, $skipAuth = false)
     {
         $options = ['headers' => $headers];
 
@@ -52,6 +52,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
         if (is_string($response)) {
             $response = $this->getFixture($response);
+        }
+
+        if ($skipAuth) {
+            $options['openstack.skip_auth'] = true;
         }
 
         $this->client

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -6,6 +6,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Message;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
+use Prophecy\Prophecy\MethodProphecy;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
@@ -42,9 +43,12 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         return Message::parseResponse(file_get_contents($path));
     }
 
-    protected function setupMock($method, $path, $body = null, array $headers = [], $response = null, $skipAuth = false)
+    protected function setupMock($method, $path, $body = null, array $headers = [], $response = null, $skipAuth = false): MethodProphecy
     {
-        $options = ['headers' => $headers];
+        $options = [
+            'headers'             => $headers,
+            'openstack.skip_auth' => $skipAuth,
+        ];
 
         if (!empty($body)) {
             $options[is_array($body) ? 'json' : 'body'] = $body;
@@ -54,11 +58,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             $response = $this->getFixture($response);
         }
 
-        if ($skipAuth) {
-            $options['openstack.skip_auth'] = true;
-        }
-
-        $this->client
+        return $this->client
             ->request($method, $path, $options)
             ->shouldBeCalled()
             ->willReturn($response);


### PR DESCRIPTION
The `AuthHandler` didn't use authorization for POST requests which have `tokens` in uri. This was created to avoid infinite recursion when obtaining a token would require obtaining a token - https://github.com/php-opencloud/openstack/blob/9f817df9407a7f59579f001c00daba0a8f00de59/src/Common/Auth/AuthHandler.php#L65. 

However this emerges another problem: if swift container name has `tokens` in it, the request uri would contain this term. So any POST request would be sent without token. 

This PR removes that check and uses a separate key `skipAuth` in the `Api` classes to mark api requests which must skip token generation. 