### PR TITLE
add errorVerbosity

### DIFF
--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -13,31 +13,47 @@ Only the ``authUrl`` is mandatory to create the client. But you will have to pro
 credentials to each service you create. So it is recommended to provide them when creating the client which
 would propagate these options to each service.
 
+Authenticate
+------------
+
 There are different ways to provide the authentication credentials. See the :doc:`services/identity/v3/tokens`
 section for the full list of options. You should provide credentials to the ``OpenStack`` constructor as an array
 the same way you provide options to ``generateToken`` method of the ``Identity`` service.
 
-Authenticate with username
---------------------------
+By username
+~~~~~~~~~~~
 
 The most common way to authenticate is using the username and password of the user. You should also provide the Domain ID
 as usernames will not be unique across an entire OpenStack installation
 
 .. sample:: Setup/username.php
 
-Authenticate with user ID
--------------------------
+By user ID
+~~~~~~~~~~
 
 .. sample:: Setup/user_id.php
 
-Authenticate application credential ID
---------------------------------------
+By application credential ID
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. sample:: Setup/application_credential_id.php
 
-Authenticate using token ID
----------------------------
+By token ID
+~~~~~~~~~~~
 
 If you already have a valid token, you can use it to authenticate.
 
 .. sample:: Setup/token_id.php
+
+Other options
+-------------
+
+For production environments it is recommended to decrease error reporting not to expose sensitive information. It can be done
+by setting the ``errorVerbosity`` key to ``0`` in the options array. It is set to 2 by default.
+
+.. code-block:: php
+
+    $openstack = new OpenStack\OpenStack([
+        'errorVerbosity' => 0,
+        // other options
+    ]);

--- a/src/Common/Auth/IdentityService.php
+++ b/src/Common/Auth/IdentityService.php
@@ -9,7 +9,7 @@ interface IdentityService
     /**
      * Authenticates and retrieves back a token and catalog.
      *
-     * @return array The FIRST key is {@see Token} instance, the SECOND key is a {@see Catalog} instance
+     * @return array{0: \OpenStack\Common\Auth\Token, 1: string} The FIRST key is {@see Token} instance, the SECOND key is a URL of the service
      */
     public function authenticate(array $options): array;
 }

--- a/src/Common/Error/Builder.php
+++ b/src/Common/Error/Builder.php
@@ -54,7 +54,7 @@ class Builder
      */
     private function linkIsValid(string $link): bool
     {
-        $link = $this->docDomain . $link;
+        $link = $this->docDomain.$link;
 
         try {
             return $this->client->request('HEAD', $link)->getStatusCode() < 400;
@@ -69,16 +69,16 @@ class Builder
     public function str(MessageInterface $message, int $verbosity = 0): string
     {
         if ($message instanceof RequestInterface) {
-            $msg = trim($message->getMethod() . ' ' . $message->getRequestTarget());
-            $msg .= ' HTTP/' . $message->getProtocolVersion();
+            $msg = trim($message->getMethod().' '.$message->getRequestTarget());
+            $msg .= ' HTTP/'.$message->getProtocolVersion();
             if (!$message->hasHeader('host')) {
-                $msg .= "\r\nHost: " . $message->getUri()->getHost();
+                $msg .= "\r\nHost: ".$message->getUri()->getHost();
             }
         } else {
             if ($message instanceof ResponseInterface) {
-                $msg = 'HTTP/' . $message->getProtocolVersion() . ' '
-                    . $message->getStatusCode() . ' '
-                    . $message->getReasonPhrase();
+                $msg = 'HTTP/'.$message->getProtocolVersion().' '
+                    .$message->getStatusCode().' '
+                    .$message->getReasonPhrase();
             } else {
                 throw new \InvalidArgumentException('Unknown message type');
             }
@@ -89,7 +89,7 @@ class Builder
         }
 
         foreach ($message->getHeaders() as $name => $values) {
-            $msg .= "\r\n{$name}: " . implode(', ', $values);
+            $msg .= "\r\n{$name}: ".implode(', ', $values);
         }
 
         if ($verbosity < 2) {
@@ -97,7 +97,7 @@ class Builder
         }
 
         if (ini_get('memory_limit') < 0 || $message->getBody()->getSize() < ini_get('memory_limit')) {
-            $msg .= "\r\n\r\n" . $message->getBody();
+            $msg .= "\r\n\r\n".$message->getBody();
         }
 
         return trim($msg);
@@ -106,7 +106,7 @@ class Builder
     /**
      * Helper method responsible for constructing and returning {@see BadResponseError} exceptions.
      *
-     * @param RequestInterface $request The faulty request
+     * @param RequestInterface  $request  The faulty request
      * @param ResponseInterface $response The error-filled response
      */
     public function httpError(RequestInterface $request, ResponseInterface $response, int $verbosity = 0): BadResponseError
@@ -120,16 +120,16 @@ class Builder
         );
 
         $message .= $this->header('Request');
-        $message .= $this->str($request, $verbosity) . PHP_EOL . PHP_EOL;
+        $message .= $this->str($request, $verbosity).PHP_EOL.PHP_EOL;
 
         $message .= $this->header('Response');
-        $message .= $this->str($response, $verbosity) . PHP_EOL . PHP_EOL;
+        $message .= $this->str($response, $verbosity).PHP_EOL.PHP_EOL;
 
         $message .= $this->header('Further information');
         $message .= $this->getStatusCodeMessage($response->getStatusCode());
 
         $message .= 'Visit http://docs.php-opencloud.com/en/latest/http-codes for more information about debugging '
-            . 'HTTP status codes, or file a support issue on https://github.com/php-opencloud/openstack/issues.';
+            .'HTTP status codes, or file a support issue on https://github.com/php-opencloud/openstack/issues.';
 
         $e = new BadResponseError($message);
         $e->setRequest($request);
@@ -153,9 +153,9 @@ class Builder
     /**
      * Helper method responsible for constructing and returning {@see UserInputError} exceptions.
      *
-     * @param string $expectedType The type that was expected from the user
-     * @param mixed $userValue The incorrect value the user actually provided
-     * @param string|null $furtherLink a link to further information if necessary (optional)
+     * @param string      $expectedType The type that was expected from the user
+     * @param mixed       $userValue    The incorrect value the user actually provided
+     * @param string|null $furtherLink  a link to further information if necessary (optional)
      */
     public function userInputError(string $expectedType, $userValue, string $furtherLink = null): UserInputError
     {
@@ -170,7 +170,7 @@ class Builder
         $message .= 'Please ensure that the value adheres to the expectation above. ';
 
         if ($furtherLink && $this->linkIsValid($furtherLink)) {
-            $message .= sprintf('Visit %s for more information about input arguments. ', $this->docDomain . $furtherLink);
+            $message .= sprintf('Visit %s for more information about input arguments. ', $this->docDomain.$furtherLink);
         }
 
         $message .= 'If you run into trouble, please open a support issue on https://github.com/php-opencloud/openstack/issues.';

--- a/src/Common/Error/Builder.php
+++ b/src/Common/Error/Builder.php
@@ -54,7 +54,7 @@ class Builder
      */
     private function linkIsValid(string $link): bool
     {
-        $link = $this->docDomain.$link;
+        $link = $this->docDomain . $link;
 
         try {
             return $this->client->request('HEAD', $link)->getStatusCode() < 400;
@@ -66,39 +66,50 @@ class Builder
     /**
      * @codeCoverageIgnore
      */
-    public function str(MessageInterface $message): string
+    public function str(MessageInterface $message, int $verbosity = 0): string
     {
         if ($message instanceof RequestInterface) {
-            $msg = trim($message->getMethod().' '
-                    .$message->getRequestTarget())
-                .' HTTP/'.$message->getProtocolVersion();
+            $msg = trim($message->getMethod() . ' ' . $message->getRequestTarget());
+            $msg .= ' HTTP/' . $message->getProtocolVersion();
             if (!$message->hasHeader('host')) {
-                $msg .= "\r\nHost: ".$message->getUri()->getHost();
+                $msg .= "\r\nHost: " . $message->getUri()->getHost();
             }
-        } elseif ($message instanceof ResponseInterface) {
-            $msg = 'HTTP/'.$message->getProtocolVersion().' '
-                .$message->getStatusCode().' '
-                .$message->getReasonPhrase();
+        } else {
+            if ($message instanceof ResponseInterface) {
+                $msg = 'HTTP/' . $message->getProtocolVersion() . ' '
+                    . $message->getStatusCode() . ' '
+                    . $message->getReasonPhrase();
+            } else {
+                throw new \InvalidArgumentException('Unknown message type');
+            }
+        }
+
+        if ($verbosity < 1) {
+            return $msg;
         }
 
         foreach ($message->getHeaders() as $name => $values) {
-            $msg .= "\r\n{$name}: ".implode(', ', $values);
+            $msg .= "\r\n{$name}: " . implode(', ', $values);
+        }
+
+        if ($verbosity < 2) {
+            return $msg;
         }
 
         if (ini_get('memory_limit') < 0 || $message->getBody()->getSize() < ini_get('memory_limit')) {
-            $msg .= "\r\n\r\n".$message->getBody();
+            $msg .= "\r\n\r\n" . $message->getBody();
         }
 
-        return $msg;
+        return trim($msg);
     }
 
     /**
      * Helper method responsible for constructing and returning {@see BadResponseError} exceptions.
      *
-     * @param RequestInterface  $request  The faulty request
+     * @param RequestInterface $request The faulty request
      * @param ResponseInterface $response The error-filled response
      */
-    public function httpError(RequestInterface $request, ResponseInterface $response): BadResponseError
+    public function httpError(RequestInterface $request, ResponseInterface $response, int $verbosity = 0): BadResponseError
     {
         $message = $this->header('HTTP Error');
 
@@ -109,16 +120,16 @@ class Builder
         );
 
         $message .= $this->header('Request');
-        $message .= trim($this->str($request)).PHP_EOL.PHP_EOL;
+        $message .= $this->str($request, $verbosity) . PHP_EOL . PHP_EOL;
 
         $message .= $this->header('Response');
-        $message .= trim($this->str($response)).PHP_EOL.PHP_EOL;
+        $message .= $this->str($response, $verbosity) . PHP_EOL . PHP_EOL;
 
         $message .= $this->header('Further information');
         $message .= $this->getStatusCodeMessage($response->getStatusCode());
 
         $message .= 'Visit http://docs.php-opencloud.com/en/latest/http-codes for more information about debugging '
-            .'HTTP status codes, or file a support issue on https://github.com/php-opencloud/openstack/issues.';
+            . 'HTTP status codes, or file a support issue on https://github.com/php-opencloud/openstack/issues.';
 
         $e = new BadResponseError($message);
         $e->setRequest($request);
@@ -142,9 +153,9 @@ class Builder
     /**
      * Helper method responsible for constructing and returning {@see UserInputError} exceptions.
      *
-     * @param string      $expectedType The type that was expected from the user
-     * @param mixed       $userValue    The incorrect value the user actually provided
-     * @param string|null $furtherLink  a link to further information if necessary (optional)
+     * @param string $expectedType The type that was expected from the user
+     * @param mixed $userValue The incorrect value the user actually provided
+     * @param string|null $furtherLink a link to further information if necessary (optional)
      */
     public function userInputError(string $expectedType, $userValue, string $furtherLink = null): UserInputError
     {
@@ -159,7 +170,7 @@ class Builder
         $message .= 'Please ensure that the value adheres to the expectation above. ';
 
         if ($furtherLink && $this->linkIsValid($furtherLink)) {
-            $message .= sprintf('Visit %s for more information about input arguments. ', $this->docDomain.$furtherLink);
+            $message .= sprintf('Visit %s for more information about input arguments. ', $this->docDomain . $furtherLink);
         }
 
         $message .= 'If you run into trouble, please open a support issue on https://github.com/php-opencloud/openstack/issues.';

--- a/src/Common/Service/Builder.php
+++ b/src/Common/Service/Builder.php
@@ -7,11 +7,8 @@ namespace OpenStack\Common\Service;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware as GuzzleMiddleware;
 use OpenStack\Common\Auth\IdentityService;
-use OpenStack\Common\Auth\Token;
 use OpenStack\Common\Transport\HandlerStackFactory;
-use OpenStack\Common\Transport\Middleware;
 use OpenStack\Common\Transport\Utils;
 
 /**
@@ -37,7 +34,7 @@ class Builder
     private $defaults = ['urlType' => 'publicURL'];
 
     /**
-     * @param array $globalOptions options that will be applied to every service created by this builder.
+     * @param array  $globalOptions options that will be applied to every service created by this builder.
      *                              Eventually they will be merged (and if necessary overridden) by the
      *                              service-specific options passed in
      * @param string $rootNamespace API classes' root namespace
@@ -50,8 +47,8 @@ class Builder
 
     private function getClasses($namespace)
     {
-        $namespace = $this->rootNamespace . '\\' . $namespace;
-        $classes = [$namespace . '\\Api', $namespace . '\\Service'];
+        $namespace = $this->rootNamespace.'\\'.$namespace;
+        $classes   = [$namespace.'\\Api', $namespace.'\\Service'];
 
         foreach ($classes as $class) {
             if (!class_exists($class)) {
@@ -68,8 +65,8 @@ class Builder
      * directly - this setup includes the configuration of the HTTP client's base URL, and the
      * attachment of an authentication handler.
      *
-     * @param string $namespace The namespace of the service
-     * @param array $serviceOptions The service-specific options to use
+     * @param string $namespace      The namespace of the service
+     * @param array  $serviceOptions The service-specific options to use
      */
     public function createService(string $namespace, array $serviceOptions = []): ServiceInterface
     {
@@ -88,12 +85,12 @@ class Builder
         if (!isset($options['httpClient']) || !($options['httpClient'] instanceof ClientInterface)) {
             if (false !== stripos($serviceName, 'identity')) {
                 $baseUrl = $options['authUrl'];
-                $token = null;
+                $token   = null;
             } else {
                 [$token, $baseUrl] = $options['identityService']->authenticate($options);
             }
 
-            $stack = HandlerStackFactory::createWithOptions(array_merge($options, ['token' => $token]));
+            $stack        = HandlerStackFactory::createWithOptions(array_merge($options, ['token' => $token]));
             $microVersion = $options['microVersion'] ?? null;
 
             $options['httpClient'] = $this->httpClient($baseUrl, $stack, $options['catalogType'], $microVersion);

--- a/src/Common/Transport/HandlerStack.php
+++ b/src/Common/Transport/HandlerStack.php
@@ -7,6 +7,9 @@ namespace OpenStack\Common\Transport;
  */
 class HandlerStack
 {
+    /**
+     * @deprecated use \OpenStack\Common\Transport\HandlerStackFactory::createWithOptions instead
+     */
     public static function create(callable $handler = null): \GuzzleHttp\HandlerStack
     {
         return HandlerStackFactory::create($handler);

--- a/src/Common/Transport/HandlerStackFactory.php
+++ b/src/Common/Transport/HandlerStackFactory.php
@@ -5,15 +5,53 @@ declare(strict_types=1);
 namespace OpenStack\Common\Transport;
 
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware as GuzzleMiddleware;
 use GuzzleHttp\Utils;
 
 class HandlerStackFactory
 {
+    /**
+     * @deprecated use \OpenStack\Common\Transport\HandlerStackFactory::createWithOptions instead
+     */
     public static function create(callable $handler = null): HandlerStack
     {
         $stack = new HandlerStack($handler ?: Utils::chooseHandler());
         $stack->push(Middleware::httpErrors(), 'http_errors');
         $stack->push(Middleware::prepareBody(), 'prepare_body');
+
+        return $stack;
+    }
+
+    /**
+     * Creates a new HandlerStack with the given options
+     *
+     * @param array{
+     *     handler: callable,
+     *     authHandler: callable,
+     *     token: \OpenStack\Common\Auth\Token,
+     *     errorVerbosity: int,
+     *     debugLog: bool,
+     *     logger: \Psr\Log\LoggerInterface,
+     *     messageFormatter: \GuzzleHttp\MessageFormatter
+     * } $options
+     */
+    public static function createWithOptions(array $options): HandlerStack
+    {
+        $stack = new HandlerStack($options['handler'] ?? Utils::chooseHandler());
+        $stack->push(Middleware::httpErrors($options['errorVerbosity'] ?? 0), 'http_errors');
+        $stack->push(GuzzleMiddleware::prepareBody(), 'prepare_body');
+
+        if (!empty($options['authHandler'])){
+            $stack->push(Middleware::authHandler($options['authHandler'], $options['token'] ?? null));
+        }
+
+        if (!empty($options['debugLog'])
+            && !empty($options['logger'])
+            && !empty($options['messageFormatter'])
+        ) {
+            $logMiddleware = GuzzleMiddleware::log($options['logger'], $options['messageFormatter']);
+            $stack->push($logMiddleware, 'logger');
+        }
 
         return $stack;
     }

--- a/src/Common/Transport/HandlerStackFactory.php
+++ b/src/Common/Transport/HandlerStackFactory.php
@@ -23,7 +23,7 @@ class HandlerStackFactory
     }
 
     /**
-     * Creates a new HandlerStack with the given options
+     * Creates a new HandlerStack with the given options.
      *
      * @param array{
      *     handler: callable,
@@ -37,11 +37,11 @@ class HandlerStackFactory
      */
     public static function createWithOptions(array $options): HandlerStack
     {
-        $stack = new HandlerStack($options['handler'] ?? Utils::chooseHandler());
+        $stack = new HandlerStack($options['handler']                  ?? Utils::chooseHandler());
         $stack->push(Middleware::httpErrors($options['errorVerbosity'] ?? 0), 'http_errors');
         $stack->push(GuzzleMiddleware::prepareBody(), 'prepare_body');
 
-        if (!empty($options['authHandler'])){
+        if (!empty($options['authHandler'])) {
             $stack->push(Middleware::authHandler($options['authHandler'], $options['token'] ?? null));
         }
 

--- a/src/Common/Transport/Middleware.php
+++ b/src/Common/Transport/Middleware.php
@@ -15,16 +15,16 @@ use Psr\Log\LogLevel;
 
 final class Middleware
 {
-    public static function httpErrors(): callable
+    public static function httpErrors(int $verbosity = 0): callable
     {
-        return function (callable $handler) {
-            return function ($request, array $options) use ($handler) {
+        return function (callable $handler) use ($verbosity) {
+            return function ($request, array $options) use ($handler, $verbosity) {
                 return $handler($request, $options)->then(
-                    function (ResponseInterface $response) use ($request) {
+                    function (ResponseInterface $response) use ($request, $verbosity) {
                         if ($response->getStatusCode() < 400) {
                             return $response;
                         }
-                        throw (new Builder())->httpError($request, $response);
+                        throw (new Builder())->httpError($request, $response, $verbosity);
                     }
                 );
             };

--- a/src/Identity/v3/Service.php
+++ b/src/Identity/v3/Service.php
@@ -45,7 +45,7 @@ class Service extends AbstractService implements IdentityService
         $name      = $options['catalogName'];
         $type      = $options['catalogType'];
         $region    = $options['region'];
-        $interface = isset($options['interface']) ? $options['interface'] : Enum::INTERFACE_PUBLIC;
+        $interface = $options['interface'] ?? Enum::INTERFACE_PUBLIC;
 
         if ($baseUrl = $token->catalog->getServiceUrl($name, $type, $region, $interface)) {
             return [$token, $baseUrl];

--- a/src/OpenStack.php
+++ b/src/OpenStack.php
@@ -36,6 +36,9 @@ class OpenStack
      */
     public function __construct(array $options = [], Builder $builder = null)
     {
+        $defaults = ['errorVerbosity' => 2];
+        $options = array_merge($defaults, $options);
+
         if (!isset($options['identityService'])) {
             $options['identityService'] = $this->getDefaultIdentityService($options);
         }
@@ -49,15 +52,7 @@ class OpenStack
             throw new \InvalidArgumentException("'authUrl' is a required option");
         }
 
-        $stack = HandlerStackFactory::create();
-
-        if (!empty($options['debugLog'])
-            && !empty($options['logger'])
-            && !empty($options['messageFormatter'])
-        ) {
-            $logMiddleware = GuzzleMiddleware::log($options['logger'], $options['messageFormatter']);
-            $stack->push($logMiddleware, 'logger');
-        }
+        $stack = HandlerStackFactory::createWithOptions(array_merge($options, ['token' => null]));
 
         $clientOptions = [
             'base_uri' => Utils::normalizeUrl($options['authUrl']),

--- a/src/OpenStack.php
+++ b/src/OpenStack.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OpenStack;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Middleware as GuzzleMiddleware;
 use OpenStack\Common\Service\Builder;
 use OpenStack\Common\Transport\HandlerStackFactory;
 use OpenStack\Common\Transport\Utils;
@@ -37,7 +36,7 @@ class OpenStack
     public function __construct(array $options = [], Builder $builder = null)
     {
         $defaults = ['errorVerbosity' => 2];
-        $options = array_merge($defaults, $options);
+        $options  = array_merge($defaults, $options);
 
         if (!isset($options['identityService'])) {
             $options['identityService'] = $this->getDefaultIdentityService($options);

--- a/tests/sample/Compute/v2/TestCase.php
+++ b/tests/sample/Compute/v2/TestCase.php
@@ -68,7 +68,7 @@ abstract class TestCase extends \OpenStack\Sample\TestCase
             ]
         );
 
-        $server->waitUntilActive(120);
+        $server->waitUntilActive(300);
         $this->assertEquals('ACTIVE', $server->status);
 
         return $server;

--- a/tests/sample/Identity/v3/TokenTest.php
+++ b/tests/sample/Identity/v3/TokenTest.php
@@ -80,7 +80,8 @@ class TokenTest extends TestCase
     {
         $options = $this->getAuthOpts();
         $password = $options['user']['password'] . $this->randomStr();
-        $options['user']['password'] .= $password;
+        $options['user']['id'] = $password;
+        $options['user']['password'] = $password;
 
         $openstack = new OpenStack($options);
         $this->expectException(BadResponseError::class);
@@ -91,8 +92,10 @@ class TokenTest extends TestCase
     public function testInvalidPasswordHidesPassword()
     {
         $options = $this->getAuthOpts();
+
         $password = $options['user']['password'] . $this->randomStr();
-        $options['user']['password'] .= $password;
+        $options['user']['id'] = $password;
+        $options['user']['password'] = $password;
 
         $openstack = new OpenStack(array_merge($options, ['errorVerbosity' => 0]));
         $this->expectException(BadResponseError::class);
@@ -101,7 +104,6 @@ class TokenTest extends TestCase
             $openstack->objectStoreV1();
         } catch (BadResponseError $e) {
             $this->assertStringNotContainsString($password, $e->getMessage());
-            print_r($e->getMessage());
 
             throw $e;
         }

--- a/tests/sample/Identity/v3/TokenTest.php
+++ b/tests/sample/Identity/v3/TokenTest.php
@@ -2,7 +2,10 @@
 
 namespace OpenStack\Sample\Identity\v3;
 
+use GuzzleHttp\Exception\ClientException;
+use OpenStack\Common\Error\BadResponseError;
 use OpenStack\Identity\v3\Models\Token;
+use OpenStack\OpenStack;
 
 class TokenTest extends TestCase
 {
@@ -73,4 +76,35 @@ class TokenTest extends TestCase
         $this->assertFalse($token->validate());
     }
 
+    public function testInvalidPassword()
+    {
+        $options = $this->getAuthOpts();
+        $password = $options['user']['password'] . $this->randomStr();
+        $options['user']['password'] .= $password;
+
+        $openstack = new OpenStack($options);
+        $this->expectException(BadResponseError::class);
+
+        $openstack->objectStoreV1();
+    }
+
+    public function testInvalidPasswordHidesPassword()
+    {
+        $options = $this->getAuthOpts();
+        $password = $options['user']['password'] . $this->randomStr();
+        $options['user']['password'] .= $password;
+
+        $openstack = new OpenStack(array_merge($options, ['errorVerbosity' => 0]));
+        $this->expectException(BadResponseError::class);
+
+        try {
+            $openstack->objectStoreV1();
+        } catch (BadResponseError $e) {
+            $this->assertStringNotContainsString($password, $e->getMessage());
+            print_r($e->getMessage());
+
+            throw $e;
+        }
+
+    }
 }

--- a/tests/unit/Common/Error/BuilderTest.php
+++ b/tests/unit/Common/Error/BuilderTest.php
@@ -27,13 +27,16 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
         self::assertInstanceOf(Builder::class, new Builder($this->client->reveal()));
     }
 
-    public function test_it_builds_http_errors()
+    /**
+     * @dataProvider verbosityProvider
+     */
+    public function test_it_builds_http_errors(int $verbosity)
     {
         $request = new Request('POST', '/servers');
         $response = new Response(400, [], Utils::streamFor('Invalid parameters'));
 
-        $requestStr = trim($this->builder->str($request));
-        $responseStr = trim($this->builder->str($response));
+        $requestStr = $this->builder->str($request, $verbosity);
+        $responseStr = $this->builder->str($response, $verbosity);
 
         $errorMessage = <<<EOT
 HTTP Error
@@ -57,7 +60,19 @@ EOT;
         $e->setRequest($request);
         $e->setResponse($response);
 
-        self::assertEquals($e, $this->builder->httpError($request, $response));
+        self::assertEquals($e, $this->builder->httpError($request, $response, $verbosity));
+    }
+
+    /**
+     * Provides different verbosity levels.
+     */
+    public function verbosityProvider(): array
+    {
+        return [
+            [0],
+            [1],
+            [2],
+        ];
     }
 
     public function test_it_builds_user_input_errors()

--- a/tests/unit/Identity/v3/ServiceTest.php
+++ b/tests/unit/Identity/v3/ServiceTest.php
@@ -10,7 +10,6 @@ use OpenStack\Identity\v3\Models;
 use OpenStack\Identity\v3\Service;
 use OpenStack\Test\TestCase;
 use Prophecy\Argument;
-use Psr\Http\Message\ResponseInterface;
 
 class ServiceTest extends TestCase
 {


### PR DESCRIPTION
Related issues:
https://github.com/php-opencloud/openstack/issues/335
https://github.com/php-opencloud/openstack/issues/398

setting `errorVerbosity` to 0 will not show header and body of request in exception.