### PR TITLE
Fix the memory limit check

### DIFF
--- a/src/Common/Error/Builder.php
+++ b/src/Common/Error/Builder.php
@@ -64,7 +64,8 @@ class Builder
     }
 
     /**
-     * Reads the PHP memory limit from the ini files and then converts it into an integer, handling PHP's shorthand byte values
+     * Reads the PHP memory limit from the ini file and then converts it into an integer, handling PHP's shorthand byte values.
+     * 
      * @see https://www.php.net/manual/en/faq.using.php#faq.using.shorthandbytes
      * 
      * @return int

--- a/src/Common/Error/Builder.php
+++ b/src/Common/Error/Builder.php
@@ -129,7 +129,7 @@ class Builder
             return $msg;
         }
 
-        if ($this->memoryLimitToInt() <= 0 || $message->getBody()->getSize() < $this->memoryLimitToInt()) {
+        if ($this->memoryLimitToInt() < 0 || $message->getBody()->getSize() < $this->memoryLimitToInt()) {
             $msg .= "\r\n\r\n" . $message->getBody();
         }
 


### PR DESCRIPTION
Closes #403

When you query `ini_get('memory_limit')` you don't always get an integer response, it returns exactly what is written inside of the PHP `.ini` file file which typically includes a shorthand value. (`K`, `M`, or `G`, all case-insensitive).

My server has the default PHP limit of `128M` which was incorrectly being evaluated as not enough by the check.

This PR corrects the behavior by first evaluating the set memory limit, including the shorthand byte values and then returns it as an integer which can then be properly compared against the message's body size.