### PR TITLE
HTTP header names are case-insensitive

### DIFF
--- a/src/ObjectStore/v1/Models/MetadataTrait.php
+++ b/src/ObjectStore/v1/Models/MetadataTrait.php
@@ -13,7 +13,7 @@ trait MetadataTrait
         $metadata = [];
 
         foreach ($response->getHeaders() as $header => $value) {
-            if (0 === strpos($header, static::METADATA_PREFIX)) {
+            if (0 === stripos($header, static::METADATA_PREFIX)) {
                 $name            = substr($header, strlen(static::METADATA_PREFIX));
                 $metadata[$name] = $response->getHeader($header)[0];
             }

--- a/src/ObjectStore/v1/Models/MetadataTrait.php
+++ b/src/ObjectStore/v1/Models/MetadataTrait.php
@@ -16,6 +16,9 @@ trait MetadataTrait
             if (0 === stripos($header, static::METADATA_PREFIX)) {
                 $name            = substr($header, strlen(static::METADATA_PREFIX));
                 $metadata[$name] = $response->getHeader($header)[0];
+                if ($name !== strtolower($name)) {
+                    $metadata[strtolower($name)] = $response->getHeader($header)[0];
+                }
             }
         }
 

--- a/src/ObjectStore/v1/Models/MetadataTrait.php
+++ b/src/ObjectStore/v1/Models/MetadataTrait.php
@@ -15,10 +15,7 @@ trait MetadataTrait
         foreach ($response->getHeaders() as $header => $value) {
             if (0 === stripos($header, static::METADATA_PREFIX)) {
                 $name            = substr($header, strlen(static::METADATA_PREFIX));
-                $metadata[$name] = $response->getHeader($header)[0];
-                if ($name !== strtolower($name)) {
-                    $metadata[strtolower($name)] = $response->getHeader($header)[0];
-                }
+                $metadata[$name] = $metadata[strtolower($name)] = $response->getHeader($header)[0];
             }
         }
 


### PR DESCRIPTION
I guess a Guzzle update or the swift provider HTTP server or a Swift update (or an intermediary proxy) changed the case of the HTTP headers and... `getMetadata()` started being empty what drove me crazy until I understood it.