### PR TITLE
make swift metadata header case insensitive 

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        openstack_version: [ "stable/2023.2" ]
         php_version: [ 8.1 ]
         include:
           - name: "bobcat"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,13 +31,13 @@ jobs:
           - name: "zed"
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"
-          - name: "yoga"
-            openstack_version: "unmaintained/yoga"
-            ubuntu_version: "20.04"
-          - name: "wallaby"
-            openstack_version: "unmaintained/wallaby"
-            ubuntu_version: "20.04"
-            block_storage_v2: true
+          #- name: "yoga"
+          #  openstack_version: "unmaintained/yoga"
+          #  ubuntu_version: "20.04"
+          #- name: "wallaby"
+          #  openstack_version: "unmaintained/wallaby"
+          #  ubuntu_version: "20.04"
+          #  block_storage_v2: true
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} and run integration tests with php ${{matrix.php_version}}
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        openstack_version: [ "stable/wallaby", "stable/zed", "stable/2023.2" ]
         php_version: [ 8.1 ]
         include:
           - name: "bobcat"
@@ -32,10 +31,10 @@ jobs:
             openstack_version: "stable/zed"
             ubuntu_version: "20.04"
           - name: "yoga"
-            openstack_version: "stable/yoga"
+            openstack_version: "unmaintained/yoga"
             ubuntu_version: "20.04"
           - name: "wallaby"
-            openstack_version: "stable/wallaby"
+            openstack_version: "unmaintained/wallaby"
             ubuntu_version: "20.04"
             block_storage_v2: true
     runs-on: ubuntu-${{ matrix.ubuntu_version }}

--- a/src/ObjectStore/v1/Models/MetadataTrait.php
+++ b/src/ObjectStore/v1/Models/MetadataTrait.php
@@ -13,7 +13,7 @@ trait MetadataTrait
         $metadata = [];
 
         foreach ($response->getHeaders() as $header => $value) {
-            if (0 === strpos($header, static::METADATA_PREFIX)) {
+            if (0 === stripos($header, static::METADATA_PREFIX)) {
                 $name            = substr($header, strlen(static::METADATA_PREFIX));
                 $metadata[$name] = $response->getHeader($header)[0];
             }

--- a/tests/unit/ObjectStore/v1/Fixtures/GET_Container.resp
+++ b/tests/unit/ObjectStore/v1/Fixtures/GET_Container.resp
@@ -3,6 +3,8 @@ Content-Length: 341
 X-Container-Object-Count: 2
 Accept-Ranges: bytes
 X-Container-Meta-Book: TomSawyer
+X-CONTAINER-META-UPPERCASE: UPPERCASE
+x-container-meta-lowercase: lowercase
 X-Timestamp: 1389727543.65372
 X-Container-Bytes-Used: 26
 Content-Type: application/json; charset=utf-8

--- a/tests/unit/ObjectStore/v1/Fixtures/GET_Object.resp
+++ b/tests/unit/ObjectStore/v1/Fixtures/GET_Object.resp
@@ -5,6 +5,8 @@ Last-Modified: Wed, 15 Jan 2014 16:41:49 GMT
 Etag: 451e372e48e0f6b1114fa0724aa79fa1
 X-Timestamp: 1389804109.39027
 X-Object-Meta-Orig-Filename: goodbyeworld.txt
+X-OBJECT-META-UPPERCASE: UPPERCASE
+x-object-meta-lowercase: lowercase
 Content-Type: text/plain
 X-Trans-Id: tx8145a190241f4cf6b05f5-0052d82a34
 Date: Thu, 16 Jan 2014 18:51:32 GMT

--- a/tests/unit/ObjectStore/v1/Fixtures/HEAD_Account.resp
+++ b/tests/unit/ObjectStore/v1/Fixtures/HEAD_Account.resp
@@ -3,6 +3,8 @@ Content-Length: 0
 X-Account-Object-Count: 1
 X-Account-Meta-Book: MobyDick
 X-Account-Meta-Genre: Fiction
+X-ACCOUNT-META-UPPERCASE: UPPERCASE
+x-account-meta-lowercase: lowercase
 X-Timestamp: 1389453423.35964
 X-Account-Bytes-Used: 14
 X-Account-Container-Count: 2

--- a/tests/unit/ObjectStore/v1/Fixtures/HEAD_Container.resp
+++ b/tests/unit/ObjectStore/v1/Fixtures/HEAD_Container.resp
@@ -4,6 +4,8 @@ X-Container-Object-Count: 1
 Accept-Ranges: bytes
 X-Container-Meta-Book: TomSawyer
 X-Container-Meta-Author: SamuelClemens
+X-CONTAINER-META-UPPERCASE: UPPERCASE
+x-container-meta-lowercase: lowercase
 X-Timestamp: 1389727543.65372
 X-Container-Bytes-Used: 14
 Content-Type: text/plain; charset=utf-8

--- a/tests/unit/ObjectStore/v1/Fixtures/HEAD_Object.resp
+++ b/tests/unit/ObjectStore/v1/Fixtures/HEAD_Object.resp
@@ -6,6 +6,8 @@ Etag: 451e372e48e0f6b1114fa0724aa79fa1
 X-Timestamp: 1389906751.73463
 X-Object-Meta-Book: GoodbyeColumbus
 X-Object-Meta-Manufacturer: Acme
+X-OBJECT-META-UPPERCASE: UPPERCASE
+x-object-meta-lowercase: lowercase
 Content-Type: application/octet-stream
 X-Trans-Id: tx37ea34dcd1ed48ca9bc7d-0052d84b6f
 Date: Thu, 16 Jan 2014 21:13:19 GMT

--- a/tests/unit/ObjectStore/v1/Models/AccountTest.php
+++ b/tests/unit/ObjectStore/v1/Models/AccountTest.php
@@ -26,7 +26,15 @@ class AccountTest extends TestCase
         $this->account->populateFromResponse($response);
 
         self::assertEquals(1, $this->account->objectCount);
-        self::assertEquals(['Book' => 'MobyDick', 'Genre' => 'Fiction'], $this->account->metadata);
+        self::assertEquals(
+            [
+                'Book'      => 'MobyDick',
+                'Genre'     => 'Fiction',
+                'UPPERCASE' => 'UPPERCASE',
+                'lowercase' => 'lowercase',
+            ],
+            $this->account->metadata
+        );
         self::assertEquals(14, $this->account->bytesUsed);
         self::assertEquals(2, $this->account->containerCount);
     }
@@ -43,7 +51,15 @@ class AccountTest extends TestCase
     public function test_Get_Metadata()
     {
         $this->mockRequest('HEAD', '', 'HEAD_Account', null, []);
-        self::assertEquals(['Book' => 'MobyDick', 'Genre' => 'Fiction'], $this->account->getMetadata());
+        self::assertEquals(
+            [
+                'Book'      => 'MobyDick',
+                'Genre'     => 'Fiction',
+                'UPPERCASE' => 'UPPERCASE',
+                'lowercase' => 'lowercase',
+            ],
+            $this->account->getMetadata()
+        );
     }
 
     public function test_Merge_Metadata()
@@ -60,9 +76,11 @@ class AccountTest extends TestCase
         $this->mockRequest('HEAD', '', 'HEAD_Account', null, []);
 
         $headers = [
-            'X-Account-Meta-Book'         => 'Middlesex',
-            'X-Account-Meta-Author'       => 'Jeffrey Eugenides',
-            'X-Remove-Account-Meta-Genre' => 'True',
+            'X-Account-Meta-Book'             => 'Middlesex',
+            'X-Account-Meta-Author'           => 'Jeffrey Eugenides',
+            'X-Remove-Account-Meta-Genre'     => 'True',
+            'X-Remove-Account-Meta-UPPERCASE' => 'True',
+            'X-Remove-Account-Meta-lowercase' => 'True',
         ];
 
         $this->mockRequest('POST', '', 'NoContent', [], $headers);

--- a/tests/unit/ObjectStore/v1/Models/ContainerTest.php
+++ b/tests/unit/ObjectStore/v1/Models/ContainerTest.php
@@ -35,7 +35,15 @@ class ContainerTest extends TestCase
         $this->container->populateFromResponse($response);
 
         self::assertEquals(1, $this->container->objectCount);
-        self::assertEquals(['Book' => 'TomSawyer', 'Author' => 'SamuelClemens'], $this->container->metadata);
+        self::assertEquals(
+            [
+                'Book'      => 'TomSawyer',
+                'Author'    => 'SamuelClemens',
+                'UPPERCASE' => 'UPPERCASE',
+                'lowercase' => 'lowercase',
+            ],
+            $this->container->metadata
+        );
         self::assertEquals(14, $this->container->bytesUsed);
     }
 
@@ -51,7 +59,16 @@ class ContainerTest extends TestCase
     {
         $this->mockRequest('HEAD', self::NAME, 'HEAD_Container', null, []);
 
-        self::assertEquals(['Book' => 'TomSawyer', 'Author' => 'SamuelClemens'], $this->container->getMetadata());
+        self::assertEquals(
+            [
+                'Book'      => 'TomSawyer',
+                'Author'    => 'SamuelClemens',
+                'UPPERCASE' => 'UPPERCASE',
+                'lowercase' => 'lowercase',
+
+            ],
+            $this->container->getMetadata()
+        );
     }
 
     public function test_Merge_Metadata()
@@ -70,6 +87,8 @@ class ContainerTest extends TestCase
         $headers = [
             'X-Container-Meta-Book'          => 'Middlesex',
             'X-Remove-Container-Meta-Author' => 'True',
+            'X-Remove-Container-Meta-UPPERCASE' => 'True',
+            'X-Remove-Container-Meta-lowercase' => 'True',
         ];
 
         $this->mockRequest('POST', self::NAME, 'NoContent', [], $headers);
@@ -141,29 +160,27 @@ class ContainerTest extends TestCase
 
         $expected = [
             [
-                'name' => 'goodbye',
+                'name'          => 'goodbye',
                 'contentLength' => '14',
-                'lastModified' => new \DateTimeImmutable('2014-01-15T16:41:49.390270'),
-                'contentType' => 'application/octet-stream',
-                'hash' => '451e372e48e0f6b1114fa0724aa79fa1'
+                'lastModified'  => new \DateTimeImmutable('2014-01-15T16:41:49.390270'),
+                'contentType'   => 'application/octet-stream',
+                'hash'          => '451e372e48e0f6b1114fa0724aa79fa1',
             ],
             [
-                'name' => 'helloworld.json',
+                'name'          => 'helloworld.json',
                 'contentLength' => '12',
-                'lastModified' => new \DateTimeImmutable('2014-01-15T16:37:43.427570'),
-                'contentType' => 'application/json',
-                'hash' => 'ed076287532e86365e841e92bfc50d8c'
+                'lastModified'  => new \DateTimeImmutable('2014-01-15T16:37:43.427570'),
+                'contentType'   => 'application/json',
+                'hash'          => 'ed076287532e86365e841e92bfc50d8c',
             ],
         ];
 
-        for ($i = 0; $i < count($objects); $i++)
-        {
+        for ($i = 0; $i < count($objects); $i++) {
             $exp = $expected[$i];
             /** @var StorageObject $obj */
             $obj = $objects[$i];
 
-            foreach ($exp as $attr => $attrVal)
-            {
+            foreach ($exp as $attr => $attrVal) {
                 self::assertEquals($attrVal, $obj->{$attr});
             }
         }
@@ -194,7 +211,7 @@ class ContainerTest extends TestCase
         $e->setResponse(new Response(500));
 
         $this->mockRequest('HEAD', 'test/bar', $e);
-		$this->expectException(BadResponseError::class);
+        $this->expectException(BadResponseError::class);
 
         $this->container->objectExists('bar');
     }
@@ -214,11 +231,11 @@ class ContainerTest extends TestCase
             : \GuzzleHttp\Psr7\Utils::streamFor(implode('', range('A', 'X')));
 
         $data = [
-            'name' => 'object',
-            'stream'           => $stream,
-            'segmentSize'      => 10,
-            'segmentPrefix'    => 'objectPrefix',
-            'segmentContainer' => 'segments',
+            'name'               => 'object',
+            'stream'             => $stream,
+            'segmentSize'        => 10,
+            'segmentPrefix'      => 'objectPrefix',
+            'segmentContainer'   => 'segments',
             'segmentIndexFormat' => '%03d',
         ];
 

--- a/tests/unit/ObjectStore/v1/Models/ObjectTest.php
+++ b/tests/unit/ObjectStore/v1/Models/ObjectTest.php
@@ -69,6 +69,8 @@ class ObjectTest extends TestCase
         self::assertEquals([
             'Book'         => 'GoodbyeColumbus',
             'Manufacturer' => 'Acme',
+            'UPPERCASE'    => 'UPPERCASE',
+            'lowercase'    => 'lowercase',
         ], $this->object->getMetadata());
     }
 
@@ -80,6 +82,8 @@ class ObjectTest extends TestCase
             'X-Object-Meta-Author'       => 'foo',
             'X-Object-Meta-Book'         => 'GoodbyeColumbus',
             'X-Object-Meta-Manufacturer' => 'Acme',
+            'X-Object-Meta-UPPERCASE'    => 'UPPERCASE',
+            'X-Object-Meta-lowercase'    => 'lowercase',
         ];
 
         $this->mockRequest('POST', self::CONTAINER . '/' . self::NAME, 'NoContent', null, $headers);
@@ -120,7 +124,7 @@ class ObjectTest extends TestCase
         $this->mockRequest('COPY', $path, 'Created', null, $headers);
 
         $this->object->copy([
-            'destination' => $headers['Destination']
+            'destination' => $headers['Destination'],
         ]);
     }
 


### PR DESCRIPTION
supersedes https://github.com/php-opencloud/openstack/pull/406

Compares headers case insensitively, but leaves the metadata names original case for backward compatibility. 