### PR TITLE
increase sleep before testing detach. The VM must be completely up.

### DIFF
--- a/tests/sample/Compute/v2/VolumeAttachmentTest.php
+++ b/tests/sample/Compute/v2/VolumeAttachmentTest.php
@@ -70,7 +70,7 @@ PHP
         // let's wait for the server to be completely up
         // https://bugs.launchpad.net/nova/+bug/1998148
         // https://bugs.launchpad.net/nova/+bug/1960346
-        sleep(15);
+        sleep(30);
 
         require_once $this->sampleFile(
             'volume_attachments/delete.php',


### PR DESCRIPTION
This test is failing quit often for the dalmatian version