### PR TITLE
extend FloatingIP with description and subnet_id

### DIFF
--- a/samples/Networking/v2/floatingIPs/create.php
+++ b/samples/Networking/v2/floatingIPs/create.php
@@ -17,5 +17,6 @@ $networking = $openstack->networkingV2();
 $floatingIp = $networking->createFloatingIp([
     "floatingNetworkId" => "{networkId}",
     "portId"            => "{portId}",
-    'fixedIpAddress'    => '{fixedIpAddress}',
+    "fixedIpAddress"    => "{fixedIpAddress}",
+    "description"       => "{description}",
 ]);

--- a/src/Networking/v2/Extensions/Layer3/Api.php
+++ b/src/Networking/v2/Extensions/Layer3/Api.php
@@ -26,6 +26,7 @@ class Api extends AbstractApi
             'jsonKey' => 'floatingip',
             'params'  => [
                 'tenantId'          => $this->params->tenantIdJson(),
+                'description'       => $this->notRequired($this->params->descriptionJson()),
                 'floatingNetworkId' => $this->params->floatingNetworkIdJson(),
                 'fixedIpAddress'    => $this->params->fixedIpAddressJson(),
                 'floatingIpAddress' => $this->params->floatingIpAddressJson(),
@@ -53,6 +54,7 @@ class Api extends AbstractApi
             'jsonKey' => 'floatingip',
             'params'  => [
                 'id'                => $this->params->idPath(),
+                'description'       => $this->notRequired($this->params->descriptionJson()),
                 'floatingNetworkId' => $this->notRequired($this->params->floatingNetworkIdJson()),
                 'fixedIpAddress'    => $this->params->fixedIpAddressJson(),
                 'floatingIpAddress' => $this->params->floatingIpAddressJson(),

--- a/src/Networking/v2/Extensions/Layer3/ApiTrait.php
+++ b/src/Networking/v2/Extensions/Layer3/ApiTrait.php
@@ -20,7 +20,9 @@ trait ApiTrait
             'jsonKey' => 'floatingip',
             'params'  => [
                 'tenantId'          => $this->params->tenantIdJson(),
+                'description'       => $this->notRequired($this->params->descriptionJson()),
                 'floatingNetworkId' => $this->params->floatingNetworkIdJson(),
+                'subnetId'          => $this->notRequired($this->params->subnetIdJson()),
                 'fixedIpAddress'    => $this->params->fixedIpAddressJson(),
                 'floatingIpAddress' => $this->params->floatingIpAddressJson(),
                 'portId'            => $this->params->portIdJson(),
@@ -47,6 +49,7 @@ trait ApiTrait
             'jsonKey' => 'floatingip',
             'params'  => [
                 'id'                => $this->params->idPath(),
+                'description'       => $this->notRequired($this->params->descriptionJson()),
                 'floatingNetworkId' => $this->notRequired($this->params->floatingNetworkIdJson()),
                 'fixedIpAddress'    => $this->params->fixedIpAddressJson(),
                 'floatingIpAddress' => $this->params->floatingIpAddressJson(),

--- a/src/Networking/v2/Extensions/Layer3/Models/FloatingIp.php
+++ b/src/Networking/v2/Extensions/Layer3/Models/FloatingIp.php
@@ -22,6 +22,9 @@ class FloatingIp extends OperatorResource implements Listable, Creatable, Retrie
     public $status;
 
     /** @var string */
+    public $description;
+
+    /** @var string */
     public $floatingNetworkId;
 
     /** @var string */

--- a/src/Networking/v2/Extensions/Layer3/Params.php
+++ b/src/Networking/v2/Extensions/Layer3/Params.php
@@ -9,6 +9,15 @@ namespace OpenStack\Networking\v2\Extensions\Layer3;
  */
 class Params extends \OpenStack\Networking\v2\Params
 {
+    public function descriptionJson(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'description' => 'The description of the floating IP.',
+            'sentAs'      => 'description',
+        ];
+    }
+
     public function tenantIdJson(): array
     {
         return [

--- a/src/Networking/v2/Extensions/Layer3/ParamsTrait.php
+++ b/src/Networking/v2/Extensions/Layer3/ParamsTrait.php
@@ -9,6 +9,15 @@ namespace OpenStack\Networking\v2\Extensions\Layer3;
  */
 trait ParamsTrait
 {
+    public function descriptionJson(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'description' => 'The description of the floating IP.',
+            'sentAs'      => 'description',
+        ];
+    }
+
     public function floatingNetworkIdJson(): array
     {
         return [
@@ -34,6 +43,15 @@ trait ParamsTrait
             'type'        => self::STRING_TYPE,
             'description' => 'The floating IP address.',
             'sentAs'      => 'floating_ip_address',
+        ];
+    }
+
+    public function subnetIdJson(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'description' => 'The UUID of the subnet of the floating Network associated with the floating IP.',
+            'sentAs'      => 'subnet',
         ];
     }
 

--- a/tests/sample/Networking/v2/FloatingIpTest.php
+++ b/tests/sample/Networking/v2/FloatingIpTest.php
@@ -63,16 +63,19 @@ class FloatingIpTest extends TestCase
             'name'      => $this->randomStr(),
         ]);
         $fixedIp = $this->findSubnetIp($data->port, $data->internalSubnet);
+        $description = $this->randomStr();
 
         /** @var FloatingIp $floatingIp */
         require_once $this->sampleFile('floatingIPs/create.php', [
             '{networkId}'      => $data->externalNetwork->id,
             '{portId}'         => $data->port->id,
             '{fixedIpAddress}' => $fixedIp,
+            '{description}'    => $description,
         ]);
         $this->assertInstanceOf(FloatingIp::class, $floatingIp);
         $this->assertEquals($data->externalNetwork->id, $floatingIp->floatingNetworkId);
         $this->assertEquals($data->port->id, $floatingIp->portId);
+        $this->assertEquals($description, $floatingIp->description);
 
         $data->floatingIp = $floatingIp;
 
@@ -123,6 +126,7 @@ PHP
         $this->assertInstanceOf(FloatingIp::class, $floatingIp);
         $this->assertEquals($data->floatingIp->id, $floatingIp->id);
         $this->assertEmpty($floatingIp->portId);
+        $this->assertEmpty($floatingIp->description);
 
         $floatingIp->retrieve();
         $this->assertEquals($data->floatingIp->portId, $floatingIp->portId);

--- a/tests/unit/Networking/v2/Extensions/Layer3/Fixtures/FloatingIp.resp
+++ b/tests/unit/Networking/v2/Extensions/Layer3/Fixtures/FloatingIp.resp
@@ -8,6 +8,7 @@ Content-Type: application/json
         "fixed_ip_address": "10.0.0.3",
         "floating_ip_address": "172.24.4.228",
         "tenant_id": "4969c491a3c74ee4af974e6d800c62de",
+        "description": "some-floating-ip",
         "status": "ACTIVE",
         "port_id": "ce705c24-c1ef-408a-bda3-7bbd946164ab",
         "id": "2f245a7b-796b-4f26-9cf9-9e82d248fda7"

--- a/tests/unit/Networking/v2/Extensions/Layer3/Fixtures/FloatingIps.resp
+++ b/tests/unit/Networking/v2/Extensions/Layer3/Fixtures/FloatingIps.resp
@@ -11,6 +11,7 @@ Content-Type: application/json
             "floating_ip_address": "172.24.4.228",
             "port_id": "ce705c24-c1ef-408a-bda3-7bbd946164ab",
             "id": "2f245a7b-796b-4f26-9cf9-9e82d248fda7",
+            "description": "some-floating-ip",
             "status": "ACTIVE"
         },
         {
@@ -21,6 +22,7 @@ Content-Type: application/json
             "floating_ip_address": "172.24.4.227",
             "port_id": null,
             "id": "61cea855-49cb-4846-997d-801b70c71bdd",
+            "description": "some-floating-ip",
             "status": "DOWN"
         }
     ]

--- a/tests/unit/Networking/v2/Extensions/Layer3/Models/FloatingIpTest.php
+++ b/tests/unit/Networking/v2/Extensions/Layer3/Models/FloatingIpTest.php
@@ -27,12 +27,14 @@ class FloatingIpTest extends TestCase
         $expectedJson = ['floatingip' => [
             "floating_network_id" => "376da547-b977-4cfe-9cba-275c80debf57",
             "port_id"             => "ce705c24-c1ef-408a-bda3-7bbd946164ab",
+            "description"         => "some-floating-ip",
         ]];
 
         $this->mockRequest('PUT', 'v2.0/floatingips/id', new Response(202), $expectedJson, []);
 
         $this->floatingIp->floatingNetworkId = "376da547-b977-4cfe-9cba-275c80debf57";
         $this->floatingIp->portId = "ce705c24-c1ef-408a-bda3-7bbd946164ab";
+        $this->floatingIp->description = "some-floating-ip";
         $this->floatingIp->update();
     }
 
@@ -49,6 +51,10 @@ class FloatingIpTest extends TestCase
 
         $this->floatingIp->retrieve();
 
+        self::assertEquals(
+            'some-floating-ip',
+                            $this->floatingIp->description
+        );
         self::assertEquals(
             '376da547-b977-4cfe-9cba-275c80debf57',
                             $this->floatingIp->floatingNetworkId


### PR DESCRIPTION
The [OpenStack API for Floating IPs](https://docs.openstack.org/api-ref/network/v2/index.html#create-floating-ip) supports:

- an optional `description` of the floating IP
- optionally specifying a specific `subnet_id` upon creation of the floating IP

  The subnet ID is not returned on GET.

This is my first time working with php-opencloud/openstack and my first pull request to this project. I have extended the unit tests to verify the description. I did not run the integration tests but verified the changes against our OpenStack environment.