### PR TITLE
nimbusoft/flysystem-openstack-swift can't be installed due to use of json-schema 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "guzzlehttp/guzzle": "^7.0",
         "guzzlehttp/psr7": ">=1.7",
         "guzzlehttp/uri-template": "^0.2 || ^1.0",
-        "justinrainbow/json-schema": "^5.2"
+        "justinrainbow/json-schema": "^5.2 || ^6.0"
     },
     "require-dev": {
         "ext-json": "*",


### PR DESCRIPTION
Using composer 2.8.8 , it's not possible to require nimbusoft/flysystem-openstack-swift . That package uses openstack which is limited to justinrainbow/json-schema ^5.2. But composer 2.8.8 requires at least ^6.3  . This MR adds support for installing ^6.0 with openstack.